### PR TITLE
Refactored __autoload()

### DIFF
--- a/wbce/include/phpmailer/PHPMailerAutoload.php
+++ b/wbce/include/phpmailer/PHPMailerAutoload.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * PHPMailer SPL autoloader.
- * PHP Version 5
+ * PHPMailer SPL autoloader (custom).
+ * PHP Version 5.4 or newer
  * @package PHPMailer
  * @link https://github.com/PHPMailer/PHPMailer/ The PHPMailer GitHub project
+ * @author Jonathan Nessier <jonathan.nessier@neoflow.ch>
  * @author Marcus Bointon (Synchro/coolbru) <phpmailer@synchromedia.co.uk>
  * @author Jim Jagielski (jimjag) <jimjag@gmail.com>
  * @author Andy Prevost (codeworxtech) <codeworxtech@users.sourceforge.net>
@@ -17,33 +18,9 @@
  * FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-/**
- * PHPMailer SPL autoloader.
- * @param string $classname The name of the class to load
- */
-function PHPMailerAutoload($classname)
-{
-    //Can't use __DIR__ as it's only in PHP 5.3+
-    $filename = dirname(__FILE__).DIRECTORY_SEPARATOR.'class.'.strtolower($classname).'.php';
+spl_autoload_register(function($classname) {
+	$filename = __DIR__.DIRECTORY_SEPARATOR.'class.'.strtolower($classname).'.php';
     if (is_readable($filename)) {
         require $filename;
     }
-}
-
-if (version_compare(PHP_VERSION, '5.1.2', '>=')) {
-    //SPL autoloading was introduced in PHP 5.1.2
-    if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
-        spl_autoload_register('PHPMailerAutoload', true, true);
-    } else {
-        spl_autoload_register('PHPMailerAutoload');
-    }
-} else {
-    /**
-     * Fall back to traditional autoload for old PHP versions
-     * @param string $classname The name of the class to load
-     */
-    function __autoload($classname)
-    {
-        PHPMailerAutoload($classname);
-    }
-}
+}, true, true);


### PR DESCRIPTION
Refactored. __autoload() is deprecated in PHP 7.2. Refactored autoload requires PHP 5.4 or newer.