### PR TITLE
Remove empty lines after (PH/Placeholders) removal

### DIFF
--- a/wbce/modules/output_filter/filters/filterRemoveSystemPh.php
+++ b/wbce/modules/output_filter/filters/filterRemoveSystemPh.php
@@ -1,5 +1,7 @@
 <?php 
  function doFilterRemoveSystemPh($content) {
     $content=preg_replace("/<!--\(PH\).*?-->/s" ,"", $content);
+    // remove any empty lines in the content
+    $content = preg_replace("/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/", "\n", $content);
     return $content;
  }


### PR DESCRIPTION
There remain ugly empty lines within the HTML output after the (PH) Placeholders are removed.
This additional RegEx will handle it and speed up the HTML rendtionion a little bit also ;-)