### PR TITLE
add function is_countable() as a polyfill for PHP < 7.3.0. environments 

### DIFF
--- a/wbce/framework/functions.php
+++ b/wbce/framework/functions.php
@@ -1268,3 +1268,21 @@ if (!function_exists('url_encode')) {
         return str_replace($entities, $replacements, rawurlencode($string));
     }
 }
+
+
+/**
+ * is_countable()
+ * ==============
+ * This function will be implemented in PHP since version 7.3.0
+ * This polyfill function will allow the use of this function
+ * also on environments with a PHP lower than 7.3.0
+ * see also: http://php.net/manual/en/function.is-countable.php
+ *
+ * @param   unspecified  $uVar The variable you want to check 
+ * @return  bool         true or false
+ */
+if (!function_exists('is_countable')) {
+    function is_countable($uVar) {
+        return (is_array($uVar) || $uVar instanceof Countable);
+    }
+}


### PR DESCRIPTION
After this issue came up in this thread:
https://forum.wbce.org/viewtopic.php?pid=20226#p20226
I decided to implement this function into functions.php so it's ready to go, as checking with is_array() won't always do.

This function will be implemented in PHP since version 7.3.0.
This polyfill function will allow the use of this function also on environments with a PHP lower than 7.3.0
see also: http://php.net/manual/en/function.is-countable.php