### PR TITLE
Hotfix for Insert class

### DIFF
--- a/wbce/modules/simplepagehead/include.php
+++ b/wbce/modules/simplepagehead/include.php
@@ -22,7 +22,7 @@ if (!function_exists('simplepagehead')) {
 
 		// Define module vars
 		// ******************
-		
+
 		// To add other modules extend this list by adding new lines, e.g.:
 		// $module['module_name'] = array('table_name', 'id_name', 'title_field_name', 'description_field_name', 'keywords_field_name');
 		$module['news'] = array('mod_news_posts', 'post_id', 'title', 'content_short', '');
@@ -41,18 +41,18 @@ if (!function_exists('simplepagehead')) {
 
 		// Set defaults
 		$the_title = ''; //$wb->page_title;
-		$the_description = ''; //$wb->page_description; 
+		$the_description = ''; //$wb->page_description;
 		$the_keywords = ''; //$wb->page_keywords;
-		
+
 		if(!isset($section_id) AND (isset($_GET['cat_id'])) ) {
 			$section_id = $database->get_one("SELECT `section_id` FROM `".TABLE_PREFIX."sections` WHERE `page_id`=".$page_id." AND `module`='responsiveFG'");
 		}
 
-		// Look for the module name of the current section		
+		// Look for the module name of the current section
 		if(isset($page_id) && isset($section_id)) {
 			$sections_query = $database->query("SELECT module FROM ".TABLE_PREFIX."sections WHERE page_id = '$page_id' AND section_id = '$section_id'");
 			$section = $sections_query->fetchRow();
-			
+
 			// Check if the module is added to the module list
 			$module_name = $section['module'];
 			if(array_key_exists($module_name, $module)) {
@@ -63,17 +63,17 @@ if (!function_exists('simplepagehead')) {
 				$title_field_name = $module[$module_name][2];
 				$description_field_name = $module[$module_name][3];
 				$keywords_field_name = $module[$module_name][4];
-				
+
 				// Register outside object
 				global $$id_name;
 				$id_value = $$id_name;
-	
+
 				// Get the header data out of the DB
 				$query = "SELECT $title_field_name, $description_field_name FROM ".TABLE_PREFIX."$table_name WHERE $id_name = '$id_value'";
 				if ($keywords_field_name !='') {$query = "SELECT $title_field_name, $description_field_name, $keywords_field_name FROM ".TABLE_PREFIX."$table_name WHERE $id_name = '$id_value'";}
 				$query_module = $database->query($query);
 				$results_array = $query_module->fetchRow();
-				$the_title = $results_array[$title_field_name]; 
+				$the_title = $results_array[$title_field_name];
 				$the_description = strip_tags($results_array[$description_field_name]);
 				if ($keywords_field_name !='') {$the_keywords = strip_tags($results_array[$keywords_field_name]);}
 			}
@@ -83,54 +83,54 @@ if (!function_exists('simplepagehead')) {
 			$the_description = $wb->page_description;
 		}
 		else {
-			$the_description = str_replace('"', '', $the_description); 
+			$the_description = str_replace('"', '', $the_description);
 			if (strlen($the_description) > 160) {
-				if(preg_match('/.{0,160}(?:[.!?:,])/su', $the_description, $match)) {   //thanks to thorn	
+				if(preg_match('/.{0,160}(?:[.!?:,])/su', $the_description, $match)) {   //thanks to thorn
 					$the_description = $match[0];
-				}			
+				}
 				if (strlen($the_description) > 160) {
 					$pos = strpos($the_description, " ", 120);
 					if ($pos > 0) {
 						$the_description = substr($the_description, 0,  $pos);
-					}					
+					}
 				}
 			}
 		}
-		
+
 		if ($the_title=='') {$the_title = $wb->page_title; }
 		//if (strlen($the_title) < 15) {$the_title = WEBSITE_TITLE. " - " .$the_title; }
 		if (WEBSITE_TITLE != $the_title) {$the_title = WEBSITE_TITLE. " - " .$the_title; }
-		
+
 
 		if ($the_description == '') { $the_description = $wb->page_description; }
 		if ($the_description == '') { $the_description = WEBSITE_DESCRIPTION; }
-		
+
 		if ($the_keywords == '') { $the_keywords = $wb->page_keywords; }
 		if ($the_keywords == '') { $the_keywords = WEBSITE_KEYWORDS; }
-		
-		
-		 if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) META HEAD+ -->"; 
-        echo "\n";       
-        echo '<meta http-equiv="Content-Type" content="text/html; charset='; if(defined('DEFAULT_CHARSET')) { echo DEFAULT_CHARSET; } else { echo 'utf-8'; } echo "\"$endtag>\n";
-		
+
+
+		 if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) META HEAD+ -->";
+		echo "\n";
+		echo '<meta http-equiv="Content-Type" content="text/html; charset='; if(defined('DEFAULT_CHARSET')) { echo DEFAULT_CHARSET; } else { echo 'utf-8'; } echo "\"$endtag>\n";
+
 		$the_language = strtolower(LANGUAGE);
 		echo "<meta name=\"language\" content=\"$the_language\"$endtag>\n";
+
+
+		if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) TITLE+ -->";
+		echo "<title>$the_title</title>";
+		if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) TITLE- -->";
+		echo "\n";
 		
-		
-		if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) TITLE+ -->"; 
-        echo "<title>$the_title</title>"; 
-        if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) TITLE- -->"; 
-        echo "\n";
-		
-		if (OPF_AUTO_PLACEHOLDER) echo '<!--(PH) META DESC+ -->'; 
+		if (OPF_AUTO_PLACEHOLDER) echo '<!--(PH) META DESC+ -->';
 		echo '<meta name="description" content=""'."$endtag>";
-		if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) META DESC- -->"; 
+		if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) META DESC- -->";
 		echo "\n";
-		if (OPF_AUTO_PLACEHOLDER) echo '<!--(PH) META KEY+ -->'; 
+		if (OPF_AUTO_PLACEHOLDER) echo '<!--(PH) META KEY+ -->';
 		echo '<meta name="keywords" content=""'. "$endtag>";
-		if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) META KEY- -->"; 
+		if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) META KEY- -->";
 		echo "\n";
-        
+
 		I::insertMetaTag(array (
 		   "setname" => "description",
 		   "name"    => "description",
@@ -144,42 +144,42 @@ if (!function_exists('simplepagehead')) {
 		));
 
 
-		if ($favicon == 1) {              
-            $tp = WB_PATH.'/templates/'.TEMPLATE;
-            $iconInRoot = false;
-            if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) FAVICON+ -->";
-            if (file_exists($tp.'/favicon.ico')) {
-				echo '<link rel="shortcut icon" href="'.TEMPLATE_DIR.'/favicon.ico" type="image/x-icon'."\"$endtag>\n";
-			} else {
-				if (file_exists(WB_PATH.'/favicon.ico')) {
-					echo '<link rel="shortcut icon" href="'.WB_URL.'/favicon.ico'."\"$endtag>\n";
-				}			
-			}
-            if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) FAVICON- -->";
-            
-            if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) APPLE TOUCH+ -->";
-            if (file_exists($tp.'/apple-touch-icon.png')) { echo '<link rel="apple-touch-icon" href="'.TEMPLATE_DIR.'/apple-touch-icon.png'."\"$endtag>\n";  }
-            if (file_exists($tp.'/apple-touch-icon-57x57.png')) {echo '<link rel="apple-touch-icon" sizes="57x57" href="'.TEMPLATE_DIR.'/apple-touch-icon-57x57.png'."\"$endtag>\n"; }
-            if (file_exists($tp.'/apple-touch-icon-72x72.png')) { echo '<link rel="apple-touch-icon" sizes="72x72" href="'.TEMPLATE_DIR.'/apple-touch-icon-72x72.png'."\"$endtag>\n"; }
-            if (file_exists($tp.'/apple-touch-icon-76x76.png')) { echo '<link rel="apple-touch-icon" sizes="76x76" href="'.TEMPLATE_DIR.'/apple-touch-icon-76x76.png'."\"$endtag>\n"; }
-            if (file_exists($tp.'/apple-touch-icon-114x114.png')) { echo '<link rel="apple-touch-icon" sizes="114x114" href="'.TEMPLATE_DIR.'/apple-touch-icon-114x114.png'."\"$endtag>\n"; }
-            if (file_exists($tp.'/apple-touch-icon-120x120.png')) { echo '<link rel="apple-touch-icon" sizes="120x120" href="'.TEMPLATE_DIR.'/apple-touch-icon-120x120.png'."\"$endtag>\n"; }
-            if (file_exists($tp.'/apple-touch-icon-144x144.png')) { echo '<link rel="apple-touch-icon" sizes="144x144" href="'.TEMPLATE_DIR.'/apple-touch-icon-144x144.png'."\"$endtag>\n"; }
-            if (file_exists($tp.'/apple-touch-icon-152x152.png')) { echo '<link rel="apple-touch-icon" sizes="152x152" href="'.TEMPLATE_DIR.'/apple-touch-icon-152x152.png'."\"$endtag>\n"; }
-            if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) APPLE TOUCH- -->";            
-        }
-       
-		
+		if ($favicon == 1) {
+			$tp = WB_PATH.'/templates/'.TEMPLATE;
+			$iconInRoot = false;
+			if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) FAVICON+ -->";
+			if (file_exists($tp.'/favicon.ico')) {
+					    echo '<link rel="shortcut icon" href="'.TEMPLATE_DIR.'/favicon.ico" type="image/x-icon'."\"$endtag>\n";
+				    } else {
+					    if (file_exists(WB_PATH.'/favicon.ico')) {
+						    echo '<link rel="shortcut icon" href="'.WB_URL.'/favicon.ico'."\"$endtag>\n";
+					    }
+				    }
+			if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) FAVICON- -->";
+
+			if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) APPLE TOUCH+ -->";
+			if (file_exists($tp.'/apple-touch-icon.png')) { echo '<link rel="apple-touch-icon" href="'.TEMPLATE_DIR.'/apple-touch-icon.png'."\"$endtag>\n";  }
+			if (file_exists($tp.'/apple-touch-icon-57x57.png')) {echo '<link rel="apple-touch-icon" sizes="57x57" href="'.TEMPLATE_DIR.'/apple-touch-icon-57x57.png'."\"$endtag>\n"; }
+			if (file_exists($tp.'/apple-touch-icon-72x72.png')) { echo '<link rel="apple-touch-icon" sizes="72x72" href="'.TEMPLATE_DIR.'/apple-touch-icon-72x72.png'."\"$endtag>\n"; }
+			if (file_exists($tp.'/apple-touch-icon-76x76.png')) { echo '<link rel="apple-touch-icon" sizes="76x76" href="'.TEMPLATE_DIR.'/apple-touch-icon-76x76.png'."\"$endtag>\n"; }
+			if (file_exists($tp.'/apple-touch-icon-114x114.png')) { echo '<link rel="apple-touch-icon" sizes="114x114" href="'.TEMPLATE_DIR.'/apple-touch-icon-114x114.png'."\"$endtag>\n"; }
+			if (file_exists($tp.'/apple-touch-icon-120x120.png')) { echo '<link rel="apple-touch-icon" sizes="120x120" href="'.TEMPLATE_DIR.'/apple-touch-icon-120x120.png'."\"$endtag>\n"; }
+			if (file_exists($tp.'/apple-touch-icon-144x144.png')) { echo '<link rel="apple-touch-icon" sizes="144x144" href="'.TEMPLATE_DIR.'/apple-touch-icon-144x144.png'."\"$endtag>\n"; }
+			if (file_exists($tp.'/apple-touch-icon-152x152.png')) { echo '<link rel="apple-touch-icon" sizes="152x152" href="'.TEMPLATE_DIR.'/apple-touch-icon-152x152.png'."\"$endtag>\n"; }
+			if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) APPLE TOUCH- -->";
+		}
+
+
 		if ($norobotstag == 1) {
 			$indexstring = '';
 			if ($page_id === 0) {$indexstring = '<meta name="robots" content="noindex,nofollow"'. "$endtag>\n";}
-			//if (isset($_GET['id'])) {$indexstring = '<meta name="robots" content="noindex,nofollow"'. "$endtag>\n";}		 
-			echo $indexstring; 
+			//if (isset($_GET['id'])) {$indexstring = '<meta name="robots" content="noindex,nofollow"'. "$endtag>\n";}
+			echo $indexstring;
 		}
-		
+
 		if ($generator == 1) {echo '<meta name="generator" content="WBCE CMS; https://wbce.org"'."$endtag>\n";}
-		if ($notoolbartag == 1) {echo '<meta http-equiv="imagetoolbar" content="no"'."$endtag>\n"; }		
-		
+		if ($notoolbartag == 1) {echo '<meta http-equiv="imagetoolbar" content="no"'."$endtag>\n"; }
+
 		if($metaend AND OPF_AUTO_PLACEHOLDER) echo "<!--(PH) META HEAD- -->\n";
 	}
 }

--- a/wbce/modules/simplepagehead/include.php
+++ b/wbce/modules/simplepagehead/include.php
@@ -121,15 +121,29 @@ if (!function_exists('simplepagehead')) {
         echo "<title>$the_title</title>"; 
         if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) TITLE- -->"; 
         echo "\n";
+		
 		if (OPF_AUTO_PLACEHOLDER) echo '<!--(PH) META DESC+ -->'; 
-		echo '<meta name="description" content="'.$the_description."\"$endtag>"; 
+		echo '<meta name="description" content=""'."$endtag>";
 		if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) META DESC- -->"; 
 		echo "\n";
 		if (OPF_AUTO_PLACEHOLDER) echo '<!--(PH) META KEY+ -->'; 
-		echo '<meta name="keywords" content="'. $the_keywords ."\"$endtag>"; 
+		echo '<meta name="keywords" content=""'. "$endtag>";
 		if (OPF_AUTO_PLACEHOLDER) echo "<!--(PH) META KEY- -->"; 
 		echo "\n";
         
+		I::insertMetaTag(array (
+		   "setname" => "description",
+		   "name"    => "description",
+		   "content" => "$the_description"
+		));
+
+		I::insertMetaTag(array (
+		   "setname" => "keywords",
+		   "name"    => "keywords",
+		   "content" => "$the_keywords"
+		));
+
+
 		if ($favicon == 1) {              
             $tp = WB_PATH.'/templates/'.TEMPLATE;
             $iconInRoot = false;


### PR DESCRIPTION
Currently, with the Insert class, the page description and keywords are
removed from the page content when the auto placeholders are inserted.
The page description and the keywords are inserted via simplepagehead.
Maybe the insert class assumes that it receives this information from there
in some queue input instead of being pasted into the html header already?
This hotfix makes it work again, but since I'm not very familiar with
the internals of the insert class, I'm not sure if it breaks anything else.