### PR TITLE
Introduce new feature for $module_name translation

### DIFF
--- a/wbce/admin/admintools/index.php
+++ b/wbce/admin/admintools/index.php
@@ -16,11 +16,8 @@
  *
  */
 
-require('../../config.php');
-$admin = new admin('admintools', 'admintools');
-
-// Include the WB functions file
- 
+require '../../config.php';
+$admin = new admin('admintools', 'admintools'); 
 
 // Setup template object, parse vars to it, then parse it
 // Create new template object
@@ -36,26 +33,27 @@ $template->set_var('HEADING_ADMINISTRATION_TOOLS', $HEADING['ADMINISTRATION_TOOL
 
 // Insert tools into tool list
 $template->set_block('main_block', 'tool_list_block', 'tool_list');
-/*$results = $database->query("SELECT * FROM ".TABLE_PREFIX."addons WHERE type = 'module' AND `function` LIKE '%tool%' AND `function` NOT LIKE '%hidden%' AND    `directory` not in ('".(implode("','",$_SESSION['MODULE_PERMISSIONS']))."') order by name"); */
-$results = $database->query("SELECT * FROM ".TABLE_PREFIX."addons WHERE type = 'module' AND `function` LIKE '%tool%' AND `function` NOT LIKE '%hidden%' order by name");
-if($results->numRows() > 0) {
-    while($tool = $results->fetchRow()) {
-        $template->set_var('TOOL_NAME', $tool['name']);
-        $template->set_var('TOOL_DIR', $tool['directory']);
-        // check if a module description exists for the displayed backend language
-        $tool_description = false;
-        if(function_exists('file_get_contents') && file_exists(WB_PATH.'/modules/'.$tool['directory'].'/languages/'.LANGUAGE .'.php')) {
-            // read contents of the module language file into string
-            $data = @file_get_contents(WB_PATH .'/modules/' .$tool['directory'] .'/languages/' .LANGUAGE .'.php');
-            $tool_description = get_variable_content('module_description', $data, true, false);
-        }       
-        $template->set_var('TOOL_DESCRIPTION', ($tool_description === False)? $tool['description'] :$tool_description);
-        $tool_default_icon= "fa fa-graduation-cap";   
-        $tool_icon =false;
+
+$tool_default_icon = "fa fa-graduation-cap"; 
+$rTools = $database->query(
+    "SELECT `directory` FROM {TP}addons 
+     WHERE type = 'module' AND `function` LIKE '%tool%' AND `function` NOT LIKE '%hidden%' 
+     order by name"
+);
+if($rTools->numRows() > 0) {
+    while($tool = $rTools->fetchRow(MYSQL_ASSOC)) {  
+        $tool_icon = false;
         $data = @file_get_contents(WB_PATH .'/modules/' .$tool['directory'] .'/info.php');
         $tool_icon = get_variable_content('module_icon', $data, true, false);
-        $template->set_var('TOOL_ICON', ($tool_icon === False)? $tool_default_icon :$tool_icon);
         
+        $template->set_var(
+            array( 
+                'TOOL_DIR'         => $tool['directory'],
+                'TOOL_NAME'        => $admin->get_module_name($tool['directory']),
+                'TOOL_DESCRIPTION' => $admin->get_module_description($tool['directory']),
+                'TOOL_ICON'        => ($tool_icon === false) ? $tool_default_icon : $tool_icon
+            )
+        );
         $template->parse('tool_list', 'tool_list_block', true);
     }
 } else {

--- a/wbce/admin/admintools/tool.php
+++ b/wbce/admin/admintools/tool.php
@@ -10,7 +10,7 @@
  * @license GNU GPL2 (or any later version)
  */
 
-require('../../config.php');
+require '../../config.php';
 
 
 //Fetch toolname
@@ -24,53 +24,39 @@ $doSave = (isset($_POST['save_settings'])|| isset($_POST['save_default']) || (is
 // return url if something goes wrong , or back button is used
 $returnToTools = ADMIN_URL.'/admintools/index.php';
 
-$toolError= false;
+$toolError = false;
 $toolCheck = true;
 
 // test for valid tool name
-if(!preg_match('/^[a-z][a-z_\-0-9]{2,}$/i', $toolDir)) $toolCheck=false;
-
-// Check is user is logged in 
-//if ($wb->is_authenticated() !== true) $toolCheck=false; 
+if(!preg_match('/^[a-z][a-z_\-0-9]{2,}$/i', $toolDir)) 
+    $toolCheck = false;
 
 // User has absolutely no permissions , possibly even not logged in :-)?
-if (!isset($_SESSION['MODULE_PERMISSIONS'])) $toolCheck=false; 
-
-// Check if tool is installed but only if user is loged in 
-
-if ($toolCheck === true) {
-    /*$sql = 'SELECT `name` FROM `'.TABLE_PREFIX.'addons` '.
-        'WHERE `type`=\'module\' AND `function` LIKE \'%tool%\' '.
-        'AND `directory`=\''.$database->escapeString($toolDir).'\' '.
-        'AND `directory` NOT IN(\''.(implode("','",$_SESSION['MODULE_PERMISSIONS'])).'\') '; */
-	 $sql = 'SELECT `name` FROM `'.TABLE_PREFIX.'addons` '.
-        'WHERE `type`=\'module\' AND `function` LIKE \'%tool%\' '.
-	'AND `function` NOT LIKE \'%hidden%\' '. 
-        'AND `directory`=\''.$database->escapeString($toolDir).'\'';	
-    if(!($toolName = $database->get_one($sql)))  $toolCheck=false;
-}
+if (!isset($_SESSION['MODULE_PERMISSIONS'])) 
+    $toolCheck = false; 
 
 // back button triggered, so go back.
-if (isset ($_POST['admin_tools'])) {$toolCheck=false;}
+if (isset ($_POST['admin_tools'])) 
+    $toolCheck = false;
 
 // all ok go for display
 if ($toolCheck) {
 
     // Defining some path for use in the actual admin tool
-    $modulePath=WB_PATH."/modules/$toolDir/"; // we need this one later on too
-    $languagePath=$modulePath.'languages/';
-    $returnUrl= ADMIN_URL."/admintools/tool.php?tool=$toolDir";
+    $modulePath   = WB_PATH."/modules/$toolDir/"; // we need this one later on too
+    $languagePath = $modulePath.'languages/';
+    $returnUrl    = ADMIN_URL."/admintools/tool.php?tool=$toolDir";
 
     //include info,php for additional infos
-    include($modulePath."/info.php" );
+    include $modulePath."/info.php";
 
     // a few more helper vars (save values or reset to default settings)
     $saveSettings= (isset($_POST['save_settings'])|| (isset($_POST['action']) && strtolower($_POST['action']  ) == 'save'));
     $saveDefault = (isset($_POST['save_default']));
     $noPage=false;
-    if (isset($_POST['no_page']) and $_POST['no_page']=="no_page") $noPage=true;
-    if (isset($_GET['no_page']) and $_GET['no_page']=="no_page")   $noPage=true;
-    if (isset($module_nopage) and $module_nopage)                  $noPage=true;
+    if (isset($_POST['no_page']) and $_POST['no_page']=="no_page") $noPage = true;
+    if (isset($_GET['no_page']) and $_GET['no_page']=="no_page")   $noPage = true;
+    if (isset($module_nopage) and $module_nopage)                  $noPage = true;
 
     // create admin-object but suppress headers if no page is set
     // for example this offers opportunety to give back  files for download
@@ -79,42 +65,45 @@ if ($toolCheck) {
 
     // show title if not function 'save' is requested
     if(!$doSave and !$noPage and !preg_match("/backend/", $module_function) ) {
-        print '<h4><a href="'.ADMIN_URL.'/admintools/index.php" '.
-              'title="'.$HEADING['ADMINISTRATION_TOOLS'].'">'.
-               $HEADING['ADMINISTRATION_TOOLS'].'</a>'.
-              '&nbsp;&raquo;&nbsp;'.$toolName.'</h4>'."\n";
+        $sTPL = '<h4><a href="{{URL}}" title="{{HEADING_TOOLS}}">{{HEADING_TOOLS}}</a>&nbsp;&raquo;&nbsp;{{MODULE_NAME}}</h4>';
+        $aReplacements = array(
+            'URL'           => ADMIN_URL.'/admintools/index.php',
+            'MODULE_NAME'   => $admin->get_module_name($toolDir),
+            'HEADING_TOOLS' => $HEADING['ADMINISTRATION_TOOLS']
+        );
+        echo replace_vars($sTPL, $aReplacements);
     }
 
     // Loading language files we start whith default EN
     if(is_file($languagePath.'EN.php')) {
-        require_once($languagePath.'EN.php');
+        require_once $languagePath.'EN.php';
     }
     // Get actual language if exists
     if(is_file($languagePath.LANGUAGE.'.php')) {
-        require_once($languagePath.LANGUAGE.'.php');
+        require_once $languagePath.LANGUAGE.'.php';
     }
 
     //Load actual tool
     echo '<div class="adminModuleWrapper '.$toolDir.'">';
-    require(WB_PATH.'/modules/'.$toolDir.'/tool.php');
+    require WB_PATH.'/modules/'.$toolDir.'/tool.php';
     echo '</div>';
 
         // Fetch the Buffer for later filtering
         $toolOutput = ob_get_clean ();
         
         // FILTER for OPF DASHBOARD just for this module(tool)
-        $file=WB_PATH . '/modules/outputfilter_dashboard/functions.php';
+        $file = WB_PATH . '/modules/outputfilter_dashboard/functions.php';
         if (file_exists($file)) {
-            include_once ($file);
+            include_once $file;
         }
         if(function_exists('opf_controller')) { 
-            $toolOutput = opf_controller('backend', $toolOutput, $toolDir)
-;
+            $toolOutput = opf_controller('backend', $toolOutput, $toolDir);
         }
         echo $toolOutput;
 
 	// output footer if  we are not in no_page mode
-        if (!$noPage) $admin->print_footer();
+        if (!$noPage) 
+            $admin->print_footer();
         else {
             // Fetch the Buffer for later filtering
             $fullOutput = ob_get_clean ();
@@ -123,7 +112,6 @@ if ($toolCheck) {
             if(function_exists('opf_controller')) {
 		$fullOutput = opf_controller('backend', $fullOutput);
             }
-
             echo $fullOutput;
         }
 } else {
@@ -132,10 +120,10 @@ if ($toolCheck) {
 }
 
 // helper Function
-function toolMsg ($setError=false, $returnUrl="" ){
-    global $admin;
-    global $MESSAGE;
-    if ($returnUrl=="" )   $returnUrl=ADMIN_URL.'/admintools/index.php';
+function toolMsg ($setError = false, $returnUrl = "" ){
+    global $admin, $MESSAGE;
+    if ($returnUrl == "")   
+        $returnUrl = ADMIN_URL.'/admintools/index.php';
 
     // Check if there is error, otherwise say successful
     if($setError) {

--- a/wbce/admin/groups/index.php
+++ b/wbce/admin/groups/index.php
@@ -34,12 +34,12 @@ $template->set_var(array(
 
 // Get existing groups from database (and get users in that group)
 $query = "SELECT g.group_id, CONCAT(name,' (',COUNT(u.group_id),')') AS name
-						FROM ".TABLE_PREFIX."groups AS g LEFT JOIN ".TABLE_PREFIX."users AS u
-						ON (g.group_id = u.group_id
-    						OR FIND_IN_SET(g.group_id, u.groups_id) > '0')
-                        WHERE g.group_id != '1'
-                        GROUP BY g.group_id
-                        ORDER BY g.name";
+            FROM {TP}groups AS g LEFT JOIN {TP}users AS u
+            ON (g.group_id = u.group_id
+            OR FIND_IN_SET(g.group_id, u.groups_id) > '0')
+            WHERE g.group_id != '1'
+            GROUP BY g.group_id
+            ORDER BY g.name";
 
 $results = $database->query($query);
 if($database->is_error()) {
@@ -76,21 +76,20 @@ if($admin->get_permission('groups_delete') != true) {
 	$template->set_var('DISPLAY_DELETE', 'hide');
 }
 
-// Insert language headings
-$template->set_var(array(
-	'HEADING_MODIFY_DELETE_GROUP' => $HEADING['MODIFY_DELETE_GROUP'],
-	'HEADING_ADD_GROUP' => $HEADING['ADD_GROUP'],
-    'HEADING_ACCESS' => $MENU['ACCESS'],
-    'HEADING_GROUPS' => $MENU['GROUPS']
-	)
-);
-// Insert language text and messages
-$template->set_var(array(
+$template->set_var(
+    array(
+        // Insert language headings
+        'HEADING_MODIFY_DELETE_GROUP' => $HEADING['MODIFY_DELETE_GROUP'],
+        'HEADING_ADD_GROUP' => $HEADING['ADD_GROUP'],
+        'HEADING_ACCESS' => $MENU['ACCESS'],
+        'HEADING_GROUPS' => $MENU['GROUPS'],
+        
+        // Insert language text and messages
 	'TEXT_MODIFY' => $TEXT['MODIFY'],
 	'TEXT_DELETE' => $TEXT['DELETE'],
 	'TEXT_MANAGE_USERS' => ( $admin->get_permission('users') == true ) ? $TEXT['MANAGE_USERS']: "",
 	'CONFIRM_DELETE' => $MESSAGE['GROUPS_CONFIRM_DELETE']
-	)
+    )
 );
 if ( $admin->get_permission('users') == true ) $template->parse("users", "manage_users_block", true);
 // Parse template object
@@ -110,90 +109,92 @@ $template->set_var('ADVANCED_LINK', 'index.php');
 
 // Tell the browser whether or not to show advanced options
 if ( true == (isset( $_POST['advanced']) AND ( strpos( $_POST['advanced'], ">>") > 0 ) ) ) {
-	$template->set_var('DISPLAY_ADVANCED', '');
-	$template->set_var('DISPLAY_BASIC', 'display:none;');
-	$template->set_var('ADVANCED', 'yes');
-	$template->set_var('ADVANCED_BUTTON', '<< '.$TEXT['HIDE_ADVANCED']);
+    $template->set_var('DISPLAY_ADVANCED', '');
+    $template->set_var('DISPLAY_BASIC', 'display:none;');
+    $template->set_var('ADVANCED', 'yes');
+    $template->set_var('ADVANCED_BUTTON', '<< '.$TEXT['HIDE_ADVANCED']);
 } else {
-	$template->set_var('DISPLAY_ADVANCED', 'display:none;');
-	$template->set_var('DISPLAY_BASIC', '');
-	$template->set_var('ADVANCED', 'no');
-	$template->set_var('ADVANCED_BUTTON', $TEXT['SHOW_ADVANCED'].' >>');
+    $template->set_var('DISPLAY_ADVANCED', 'display:none;');
+    $template->set_var('DISPLAY_BASIC', '');
+    $template->set_var('ADVANCED', 'no');
+    $template->set_var('ADVANCED_BUTTON', $TEXT['SHOW_ADVANCED'].' >>');
 }
 
 // Insert permissions values
 if($admin->get_permission('groups_add') != true) {
-	$template->set_var('DISPLAY_ADD', 'hide');
+    $template->set_var('DISPLAY_ADD', 'hide');
 }
 
 // Insert values into module list
 $template->set_block('main_block', 'module_list_block', 'module_list');
-$result = $database->query('SELECT * FROM `'.TABLE_PREFIX.'addons` WHERE `type` = "module" AND `function` = "page" ORDER BY `name`');
+$result = $database->query('SELECT * FROM `{TP}addons` WHERE `type` = "module" AND `function` = "page" ORDER BY `name`');
 if($result->numRows() > 0) {
-	while($addon = $result->fetchRow()) {
-		$template->set_var('VALUE', $addon['directory']);
-		$template->set_var('NAME', $addon['name']);
-		$template->parse('module_list', 'module_list_block', true);
-	}
+    while($addon = $result->fetchRow()) {
+        $addon['name'] = $admin->get_module_name($addon['directory'], true, '&nbsp; <i>(%s)</i>');
+        $template->set_var('VALUE', $addon['directory']);
+        $template->set_var('NAME', $addon['name']);
+        $template->parse('module_list', 'module_list_block', true);
+    }
 }
 
 // Insert values into template list
 $template->set_block('main_block', 'template_list_block', 'template_list');
-$result = $database->query('SELECT * FROM `'.TABLE_PREFIX.'addons` WHERE `type` = "template" ORDER BY `name`');
+$result = $database->query('SELECT * FROM `{TP}addons` WHERE `type` = "template" ORDER BY `name`');
 if($result->numRows() > 0) {
-	while($addon = $result->fetchRow()) {
-		$template->set_var('VALUE', $addon['directory']);
-		$template->set_var('NAME', $addon['name']);
-		$template->parse('template_list', 'template_list_block', true);
-	}
+    while($addon = $result->fetchRow()) {
+        $template->set_var('VALUE', $addon['directory']);
+        $template->set_var('NAME', $addon['name']);
+        $template->parse('template_list', 'template_list_block', true);
+    }
 }
 
 // Insert language text and messages
-$template->set_var(array(
-								'TEXT_RESET' => $TEXT['RESET'],
-								'TEXT_ACTIVE' => $TEXT['ACTIVE'],
-								'TEXT_DISABLED' => $TEXT['DISABLED'],
-								'TEXT_PLEASE_SELECT' => $TEXT['PLEASE_SELECT'],
-								'TEXT_USERNAME' => $TEXT['USERNAME'],
-								'TEXT_PASSWORD' => $TEXT['PASSWORD'],
-								'TEXT_RETYPE_PASSWORD' => $TEXT['RETYPE_PASSWORD'],
-								'TEXT_DISPLAY_NAME' => $TEXT['DISPLAY_NAME'],
-								'TEXT_EMAIL' => $TEXT['EMAIL'],
-								'TEXT_GROUP' => $TEXT['GROUP'],
-								'TEXT_SYSTEM_PERMISSIONS' => $TEXT['SYSTEM_PERMISSIONS'],
-								'TEXT_MODULE_PERMISSIONS' => $TEXT['MODULE_PERMISSIONS'],
-								'TEXT_TEMPLATE_PERMISSIONS' => $TEXT['TEMPLATE_PERMISSIONS'],
-								'TEXT_NAME' => $TEXT['NAME'],
-								'SECTION_PAGES' => $MENU['PAGES'],
-								'SECTION_MEDIA' => $MENU['MEDIA'],
-								'SECTION_MODULES' => $MENU['MODULES'],
-								'SECTION_TEMPLATES' => $MENU['TEMPLATES'],
-								'SECTION_SETTINGS' => $MENU['SETTINGS'],
-								'SECTION_LANGUAGES' => $MENU['LANGUAGES'],
-								'SECTION_USERS' => $MENU['USERS'],
-								'SECTION_GROUPS' => $MENU['GROUPS'],
-								'SECTION_ADMINTOOLS' => $MENU['ADMINTOOLS'],
-								'TEXT_VIEW' => $TEXT['VIEW'],
-								'TEXT_ADD' => $TEXT['ADD'],
-								'TEXT_LEVEL' => $TEXT['LEVEL'],
-								'TEXT_MODIFY' => $TEXT['MODIFY'],
-								'TEXT_DELETE' => $TEXT['DELETE'],
-								'TEXT_MODIFY_CONTENT' => $TEXT['MODIFY_CONTENT'],
-								'TEXT_MODIFY_SETTINGS' => $TEXT['MODIFY_SETTINGS'],
-								'HEADING_MODIFY_INTRO_PAGE' => $HEADING['MODIFY_INTRO_PAGE'],
-								'TEXT_CREATE_FOLDER' => $TEXT['CREATE_FOLDER'],
-								'TEXT_RENAME' => $TEXT['RENAME'],
-								'TEXT_UPLOAD_FILES' => $TEXT['UPLOAD_FILES'],
-								'TEXT_BASIC' => $TEXT['BASIC'],
-								'TEXT_ADVANCED' => $TEXT['ADVANCED'],
-								'CHANGING_PASSWORD' => $MESSAGE['USERS_CHANGING_PASSWORD'],
-								'CHECKED' => ' checked="checked"',
-								'ADMIN_URL' => ADMIN_URL,
-								'WB_URL' => WB_URL,
-								'THEME_URL' => THEME_URL,
-								'FTAN' => $ftan
-								)
-						);
+$template->set_var(
+    array(
+        'TEXT_RESET' => $TEXT['RESET'],
+        'TEXT_ACTIVE' => $TEXT['ACTIVE'],
+        'TEXT_DISABLED' => $TEXT['DISABLED'],
+        'TEXT_PLEASE_SELECT' => $TEXT['PLEASE_SELECT'],
+        'TEXT_USERNAME' => $TEXT['USERNAME'],
+        'TEXT_PASSWORD' => $TEXT['PASSWORD'],
+        'TEXT_RETYPE_PASSWORD' => $TEXT['RETYPE_PASSWORD'],
+        'TEXT_DISPLAY_NAME' => $TEXT['DISPLAY_NAME'],
+        'TEXT_EMAIL' => $TEXT['EMAIL'],
+        'TEXT_GROUP' => $TEXT['GROUP'],
+        'TEXT_SYSTEM_PERMISSIONS' => $TEXT['SYSTEM_PERMISSIONS'],
+        'TEXT_MODULE_PERMISSIONS' => $TEXT['MODULE_PERMISSIONS'],
+        'TEXT_TEMPLATE_PERMISSIONS' => $TEXT['TEMPLATE_PERMISSIONS'],
+        'TEXT_NAME' => $TEXT['NAME'],
+        'SECTION_PAGES' => $MENU['PAGES'],
+        'SECTION_MEDIA' => $MENU['MEDIA'],
+        'SECTION_MODULES' => $MENU['MODULES'],
+        'SECTION_TEMPLATES' => $MENU['TEMPLATES'],
+        'SECTION_SETTINGS' => $MENU['SETTINGS'],
+        'SECTION_LANGUAGES' => $MENU['LANGUAGES'],
+        'SECTION_USERS' => $MENU['USERS'],
+        'SECTION_GROUPS' => $MENU['GROUPS'],
+        'SECTION_ADMINTOOLS' => $MENU['ADMINTOOLS'],
+        'TEXT_VIEW' => $TEXT['VIEW'],
+        'TEXT_ADD' => $TEXT['ADD'],
+        'TEXT_LEVEL' => $TEXT['LEVEL'],
+        'TEXT_MODIFY' => $TEXT['MODIFY'],
+        'TEXT_DELETE' => $TEXT['DELETE'],
+        'TEXT_MODIFY_CONTENT' => $TEXT['MODIFY_CONTENT'],
+        'TEXT_MODIFY_SETTINGS' => $TEXT['MODIFY_SETTINGS'],
+        'HEADING_MODIFY_INTRO_PAGE' => $HEADING['MODIFY_INTRO_PAGE'],
+        'TEXT_CREATE_FOLDER' => $TEXT['CREATE_FOLDER'],
+        'TEXT_RENAME' => $TEXT['RENAME'],
+        'TEXT_UPLOAD_FILES' => $TEXT['UPLOAD_FILES'],
+        'TEXT_BASIC' => $TEXT['BASIC'],
+        'TEXT_ADVANCED' => $TEXT['ADVANCED'],
+        'CHANGING_PASSWORD' => $MESSAGE['USERS_CHANGING_PASSWORD'],
+        'CHECKED' => ' checked="checked"',
+        'ADMIN_URL' => ADMIN_URL,
+        'WB_URL' => WB_URL,
+        'THEME_URL' => THEME_URL,
+        'FTAN' => $ftan
+    )
+);
 
 // Parse template for add group form
 $template->parse('main', 'main_block', false);

--- a/wbce/admin/modules/details.php
+++ b/wbce/admin/modules/details.php
@@ -28,8 +28,8 @@ $file = trim($admin->get_post('file'));
 $root_dir = realpath(WB_PATH . DIRECTORY_SEPARATOR . 'modules');
 $raw_dir = realpath($root_dir . DIRECTORY_SEPARATOR . $file);
 if(! ($file && $raw_dir && is_dir($raw_dir) && (strpos($raw_dir, $root_dir) === 0))) {
-	// module file empty or outside WBCE module folder
-	$admin->print_error($MESSAGE['GENERIC_NOT_INSTALLED']);
+    // module file empty or outside WBCE module folder
+    $admin->print_error($MESSAGE['GENERIC_NOT_INSTALLED']);
 }
 
 // Extract module folder from realpath for further usage inside script
@@ -40,14 +40,14 @@ $rModule = $database->query(
     "SELECT * FROM `{TP}addons` WHERE type = 'module' AND `directory` = '" . $database->escapeString($sModDir) . "'"
 );
 if($rModule->numRows() > 0) {
-	$aModule = $rModule->fetchRow(MYSQL_ASSOC);
+    $aModule = $rModule->fetchRow(MYSQL_ASSOC);
 }
 
 // Collect the modules Type description.
 // Since we can now have hybride modules, a single module can have different functions/types
 // associated with it.
 $TEXT['INITIALIZE'] = isset($TEXT['INITIALIZE']) ? $TEXT['INITIALIZE'] : 'Initialize';
-$TEXT['PREINIT']    = isset($TEXT['PREINIT']) ? $TEXT['PREINIT'] : 'Preinit';
+$TEXT['PREINIT']    = isset($TEXT['PREINIT'])    ? $TEXT['PREINIT']    : 'Preinit';
 $aModType = array();
 if (empty($aModule['function']))                      $aModType[] = $TEXT['UNKNOWN'];
 if (preg_match("/page/", $aModule['function']))       $aModType[] = $TEXT['PAGE'];
@@ -62,15 +62,15 @@ $sModuleType = implode($aModType,", ");
 // Get the module description or its translation if set in the language file of the module
 $aModule['description'] = $admin->get_module_description($sModDir);
 // Get the module name or its translation if set in the language file of the module
-$aModule['name'] = $admin->get_module_name($sModDir, true, ' <i>(%s)</i>');
+$aModule['name'] = $admin->get_module_name($sModDir, true, ' <i>[%s]</i>');
 
 // Create new template object
-$template = new Template(dirname($admin->correct_theme_source('modules_details.htt')));
-$template->set_file('page', 'modules_details.htt');
-$template->set_block('page', 'main_block', 'main');
+$oTemplate = new Template(dirname($admin->correct_theme_source('modules_details.htt')));
+$oTemplate->set_file('page', 'modules_details.htt');
+$oTemplate->set_block('page', 'main_block', 'main');
 
 // Hand over language strings and variables to template
-$template->set_var(
+$oTemplate->set_var(
     array( 
         'TYPE'         => $sModuleType,
         'NAME'         => $aModule['name'],
@@ -93,8 +93,8 @@ $template->set_var(
 );
 
 // Parse module object
-$template->parse('main', 'main_block', false);
-$template->pparse('output', 'page');
+$oTemplate->parse('main', 'main_block', false);
+$oTemplate->pparse('output', 'page');
 
 // Print admin footer
 $admin->print_footer();

--- a/wbce/admin/modules/index.php
+++ b/wbce/admin/modules/index.php
@@ -23,11 +23,13 @@ $template->set_block('page', 'main_block', 'main');
 
 // Insert values into module list
 $template->set_block('main_block', 'module_list_block', 'module_list');
-$result = $database->query("SELECT * FROM ".TABLE_PREFIX."addons WHERE type = 'module' order by name");
+$result = $database->query("SELECT * FROM `{TP}addons` WHERE type = 'module' order by name");
 if($result->numRows() > 0) {
-    while ($addon = $result->fetchRow()) {
-        $template->set_var('VALUE', $addon['directory']);
-        $template->set_var('NAME', $addon['name']);
+    while ($aModule = $result->fetchRow(MYSQL_ASSOC)) {
+        
+        $aModule['name'] = $admin->get_module_name($aModule['directory'], true);
+        $template->set_var('VALUE', $aModule['directory']);
+        $template->set_var('NAME',  $aModule['name']);
         $template->parse('module_list', 'module_list_block', true);
     }
 }
@@ -39,8 +41,8 @@ $template->set_block('main_block', 'upgrade_list_block', 'upgrade_list');
 $template->set_block('main_block', 'uninstall_list_block', 'uninstall_list');
 $template->set_var(
     array(
-        'INSTALL_VISIBLE' => 'hide',
-        'UPGRADE_VISIBLE' => 'hide',
+        'INSTALL_VISIBLE'   => 'hide',
+        'UPGRADE_VISIBLE'   => 'hide',
         'UNINSTALL_VISIBLE' => 'hide'
     )
 );

--- a/wbce/admin/modules/index.php
+++ b/wbce/admin/modules/index.php
@@ -17,29 +17,29 @@ require '../../config.php';
 $admin = new admin('Addons', 'modules', true, true);
 
 // Create new template object
-$template = new Template(dirname($admin->correct_theme_source('modules.htt')));
-$template->set_file('page', 'modules.htt');
-$template->set_block('page', 'main_block', 'main');
+$oTemplate = new Template(dirname($admin->correct_theme_source('modules.htt')));
+$oTemplate->set_file('page', 'modules.htt');
+$oTemplate->set_block('page', 'main_block', 'main');
 
 // Insert values into module list
-$template->set_block('main_block', 'module_list_block', 'module_list');
+$oTemplate->set_block('main_block', 'module_list_block', 'module_list');
 $result = $database->query("SELECT * FROM `{TP}addons` WHERE type = 'module' order by name");
 if($result->numRows() > 0) {
     while ($aModule = $result->fetchRow(MYSQL_ASSOC)) {
         
-        $aModule['name'] = $admin->get_module_name($aModule['directory'], true);
-        $template->set_var('VALUE', $aModule['directory']);
-        $template->set_var('NAME',  $aModule['name']);
-        $template->parse('module_list', 'module_list_block', true);
+        $aModule['name'] = $admin->get_module_name($aModule['directory'], true, ' <i>[%s]</i>');
+        $oTemplate->set_var('VALUE', $aModule['directory']);
+        $oTemplate->set_var('NAME',  $aModule['name']);
+        $oTemplate->parse('module_list', 'module_list_block', true);
     }
 }
 
 // Insert modules which includes a install.php file to install list
 $module_files = glob(WB_PATH . '/modules/*');
-$template->set_block('main_block', 'install_list_block', 'install_list');
-$template->set_block('main_block', 'upgrade_list_block', 'upgrade_list');
-$template->set_block('main_block', 'uninstall_list_block', 'uninstall_list');
-$template->set_var(
+$oTemplate->set_block('main_block', 'install_list_block', 'install_list');
+$oTemplate->set_block('main_block', 'upgrade_list_block', 'upgrade_list');
+$oTemplate->set_block('main_block', 'uninstall_list_block', 'uninstall_list');
+$oTemplate->set_var(
     array(
         'INSTALL_VISIBLE'   => 'hide',
         'UPGRADE_VISIBLE'   => 'hide',
@@ -52,26 +52,26 @@ foreach ($module_files as $index => $path) {
     if (is_dir($path)) {
         if (file_exists($path . '/install.php')) {
             $show_block = true;
-            $template->set_var('INSTALL_VISIBLE', '');
-            $template->set_var('VALUE', basename($path));
-            $template->set_var('NAME', basename($path));
-            $template->parse('install_list', 'install_list_block', true);
+            $oTemplate->set_var('INSTALL_VISIBLE', '');
+            $oTemplate->set_var('VALUE', basename($path));
+            $oTemplate->set_var('NAME', basename($path));
+            $oTemplate->parse('install_list', 'install_list_block', true);
         }
 
         if (file_exists($path . '/upgrade.php')) {
             $show_block = true;
-            $template->set_var('UPGRADE_VISIBLE', '');
-            $template->set_var('VALUE', basename($path));
-            $template->set_var('NAME', basename($path));
-            $template->parse('upgrade_list', 'upgrade_list_block', true);
+            $oTemplate->set_var('UPGRADE_VISIBLE', '');
+            $oTemplate->set_var('VALUE', basename($path));
+            $oTemplate->set_var('NAME', basename($path));
+            $oTemplate->parse('upgrade_list', 'upgrade_list_block', true);
         }
 
         if (file_exists($path . '/uninstall.php')) {
             $show_block = true;
-            $template->set_var('UNINSTALL_VISIBLE', '');
-            $template->set_var('VALUE', basename($path));
-            $template->set_var('NAME', basename($path));
-            $template->parse('uninstall_list', 'uninstall_list_block', true);
+            $oTemplate->set_var('UNINSTALL_VISIBLE', '');
+            $oTemplate->set_var('VALUE', basename($path));
+            $oTemplate->set_var('NAME', basename($path));
+            $oTemplate->parse('uninstall_list', 'uninstall_list_block', true);
         }
 
     } else {
@@ -81,34 +81,34 @@ foreach ($module_files as $index => $path) {
 
 // Insert permissions values
 if($admin->get_permission('modules_install') != true) {
-    $template->set_var('DISPLAY_INSTALL', 'hide');
+    $oTemplate->set_var('DISPLAY_INSTALL', 'hide');
 }
 if($admin->get_permission('modules_uninstall') != true) {
-    $template->set_var('DISPLAY_UNINSTALL', 'hide');
+    $oTemplate->set_var('DISPLAY_UNINSTALL', 'hide');
 }
 if($admin->get_permission('modules_view') != true) {
-    $template->set_var('DISPLAY_LIST', 'hide');
+    $oTemplate->set_var('DISPLAY_LIST', 'hide');
 }
 // only show block if there is something to show
 if(!$show_block || count($module_files) == 0 || !isset($_GET['advanced']) || $admin->get_permission('admintools') != true) {
-    $template->set_var('DISPLAY_MANUAL_INSTALL', 'hide');
+    $oTemplate->set_var('DISPLAY_MANUAL_INSTALL', 'hide');
 }
 
 // Insert language headings, urls and text messages
-$template->set_var(
+$oTemplate->set_var(
     array(
         // Headings
-        'HEADING_INSTALL_MODULE' => $HEADING['INSTALL_MODULE'],
-        'HEADING_UNINSTALL_MODULE' => $HEADING['UNINSTALL_MODULE'],
-        'OVERWRITE_NEWER_FILES' => $MESSAGE['ADDON_OVERWRITE_NEWER_FILES'],
-        'HEADING_MODULE_DETAILS' => $HEADING['MODULE_DETAILS'],
+        'HEADING_INSTALL_MODULE'      => $HEADING['INSTALL_MODULE'],
+        'HEADING_UNINSTALL_MODULE'    => $HEADING['UNINSTALL_MODULE'],
+        'OVERWRITE_NEWER_FILES'       => $MESSAGE['ADDON_OVERWRITE_NEWER_FILES'],
+        'HEADING_MODULE_DETAILS'      => $HEADING['MODULE_DETAILS'],
         'HEADING_INVOKE_MODULE_FILES' => $HEADING['INVOKE_MODULE_FILES'],
 
         // URLs
         'ADMIN_URL' => ADMIN_URL,
-        'WB_URL' => WB_URL,
+        'WB_URL'    => WB_URL,
         'THEME_URL' => THEME_URL,
-        'FTAN' => $admin->getFTAN(),
+        'FTAN'      => $admin->getFTAN(),
 
         // Text messages
         'URL_TEMPLATES' => $admin->get_permission('templates') ?
@@ -129,8 +129,8 @@ $template->set_var(
 );
 
 // Parse template object
-$template->parse('main', 'main_block', false);
-$template->pparse('output', 'page');
+$oTemplate->parse('main', 'main_block', false);
+$oTemplate->pparse('output', 'page');
 
 // Print admin footer
 $admin->print_footer();

--- a/wbce/admin/pages/index.php
+++ b/wbce/admin/pages/index.php
@@ -10,8 +10,8 @@
  * @license GNU GPL2 (or any later version)
  */
 
-require('../../config.php');
-require_once(WB_PATH.'/framework/class.admin.php');
+require '../../config.php';
+require_once WB_PATH.'/framework/class.admin.php';
 $admin = new admin('Pages', 'pages');
 
 $admin->clearIDKEY();
@@ -22,9 +22,9 @@ require_once(WB_PATH.'/framework/functions.php');
 // Include page tree and define output
 ob_start();
 if (file_exists(THEME_PATH.'/patch/page_tree.php')) {
-	require_once(THEME_PATH.'/patch/page_tree.php');
+    require_once THEME_PATH.'/patch/page_tree.php';
 } else {
-	require_once(dirname(__FILE__).'/page_tree/page_tree.php');
+    require_once __DIR__.'/page_tree/page_tree.php';
 }
 $pageTreeOutput = ob_get_clean();
 
@@ -42,108 +42,194 @@ $template->set_var('FTAN', $admin->getFTAN());
 $template->set_var('PAGE_TREE', $pageTreeOutput);
 
 
-/**
- *	Insert values into the add page form
- *
- */
+// Insert values into the add page form
 
 // Group list 1
+$query = "SELECT * FROM ".TABLE_PREFIX."groups";
+$get_groups = $database->query($query);
+$template->set_block('main_block', 'group_list_block', 'group_list');
+// Insert admin group and current group first
+$admin_group_name = $get_groups->fetchRow();
+$template->set_var(array(
+    'ID'         => 1,
+    'TOGGLE'     => '',
+    'DISABLED'   => ' disabled="disabled"',
+    'LINK_COLOR' => '000000',
+    'CURSOR'     => 'default',
+    'NAME'       => $admin_group_name['name'],
+    'CHECKED'    => ' checked="checked"'
+    )
+);
+$template->parse('group_list', 'group_list_block', true);
 
-    $query = "SELECT * FROM ".TABLE_PREFIX."groups";
-    $get_groups = $database->query($query);
-    $template->set_block('main_block', 'group_list_block', 'group_list');
-    // Insert admin group and current group first
-    $admin_group_name = $get_groups->fetchRow();
-    $template->set_var(array(
-                                    'ID' => 1,
-	'TOGGLE' => '',
-                                    'DISABLED' => ' disabled="disabled"',
-                                    'LINK_COLOR' => '000000',
-                                    'CURSOR' => 'default',
-                                    'NAME' => $admin_group_name['name'],
-                                    'CHECKED' => ' checked="checked"'
-                                    )
-                            );
-    $template->parse('group_list', 'group_list_block', true);
-
-    while($group = $get_groups->fetchRow()) {
-        // check if the user is a member of this group
-        $flag_disabled = '';
-        $flag_checked =  '';
-        $flag_cursor =   'pointer';
-        $flag_color =    '';
-        if (in_array($group["group_id"], $admin->get_groups_id())) {
-            $flag_disabled = ''; //' disabled';
-            $flag_checked =  ' checked="checked"';
-            $flag_cursor =   'default';
-            $flag_color =    '000000';
-        }
-
-        // Check if the group is allowed to edit pages
-        $system_permissions = explode(',', $group['system_permissions']);
-        if(is_numeric(array_search('pages_modify', $system_permissions))) {
-            $template->set_var(array(
-                                            'ID' => $group['group_id'],
-                                            'TOGGLE' => $group['group_id'],
-                                            'CHECKED' => $flag_checked,
-                                            'DISABLED' => $flag_disabled,
-                                            'LINK_COLOR' => $flag_color,
-                                            'CURSOR' => $flag_checked,
-                                            'NAME' => $group['name'],
-                                            )
-                                    );
-            $template->parse('group_list', 'group_list_block', true);
-        }
+while($group = $get_groups->fetchRow()) {
+    // check if the user is a member of this group
+    $flag_disabled = '';
+    $flag_checked  = '';
+    $flag_cursor   = 'pointer';
+    $flag_color    = '';
+    if (in_array($group["group_id"], $admin->get_groups_id())) {
+        $flag_disabled = ''; //' disabled';
+        $flag_checked  = ' checked="checked"';
+        $flag_cursor   = 'default';
+        $flag_color    = '000000';
     }
-// Group list 2
 
-    $query = "SELECT * FROM ".TABLE_PREFIX."groups";
-
-    $get_groups = $database->query($query);
-    $template->set_block('main_block', 'group_list_block2', 'group_list2');
-    // Insert admin group and current group first
-    $admin_group_name = $get_groups->fetchRow();
-    $template->set_var(array(
-                                    'ID' => 1,
-	'TOGGLE' => '',
-                                    'DISABLED' => ' disabled="disabled"',
-                                    'LINK_COLOR' => '000000',
-                                    'CURSOR' => 'default',
-                                    'NAME' => $admin_group_name['name'],
-                                    'CHECKED' => ' checked="checked"'
-                                    )
-                            );
-    $template->parse('group_list2', 'group_list_block2', true);
-
-    while($group = $get_groups->fetchRow()) {
-        // check if the user is a member of this group
-        $flag_disabled = '';
-        $flag_checked =  '';
-        $flag_cursor =   'pointer';
-        $flag_color =    '';
-        if (in_array($group["group_id"], $admin->get_groups_id())) {
-            $flag_disabled = ''; //' disabled';
-            $flag_checked =  ' checked="checked"';
-            $flag_cursor =   'default';
-            $flag_color =    '000000';
-        }
-
+    // Check if the group is allowed to edit pages
+    $system_permissions = explode(',', $group['system_permissions']);
+    if(is_numeric(array_search('pages_modify', $system_permissions))) {
         $template->set_var(array(
-                                        'ID' => $group['group_id'],
-                                        'TOGGLE' => $group['group_id'],
-                                        'CHECKED' => $flag_checked,
-                                        'DISABLED' => $flag_disabled,
-                                        'LINK_COLOR' => $flag_color,
-                                        'CURSOR' => $flag_cursor,
-                                        'NAME' => $group['name'],
-                                        )
-                                );
-        $template->parse('group_list2', 'group_list_block2', true);
+            'ID'         => $group['group_id'],
+            'TOGGLE'     => $group['group_id'],
+            'CHECKED'    => $flag_checked,
+            'DISABLED'   => $flag_disabled,
+            'LINK_COLOR' => $flag_color,
+            'CURSOR'     => $flag_checked,
+            'NAME'       => $group['name'],
+            )
+        );
+        $template->parse('group_list', 'group_list_block', true);
+    }
+}
+
+// Group list 2
+$get_groups = $database->query("SELECT * FROM `{TP}groups`");
+$template->set_block('main_block', 'group_list_block2', 'group_list2');
+// Insert admin group and current group first
+$admin_group_name = $get_groups->fetchRow();
+$template->set_var(array(
+    'ID'         => 1,
+    'TOGGLE'     => '',
+    'DISABLED'   => ' disabled="disabled"',
+    'LINK_COLOR' => '000000',
+    'CURSOR'     => 'default',
+    'NAME'       => $admin_group_name['name'],
+    'CHECKED'    => ' checked="checked"'
+    )
+);
+$template->parse('group_list2', 'group_list_block2', true);
+
+while($group = $get_groups->fetchRow()) {
+    // check if the user is a member of this group
+    $flag_disabled = '';
+    $flag_checked  = '';
+    $flag_cursor   = 'pointer';
+    $flag_color    =  '';
+    if (in_array($group["group_id"], $admin->get_groups_id())) {
+        $flag_disabled = ''; //' disabled';
+        $flag_checked  = ' checked="checked"';
+        $flag_cursor   = 'default';
+        $flag_color    = '000000';
     }
 
+    $template->set_var(array(
+        'ID'         => $group['group_id'],
+        'TOGGLE'     => $group['group_id'],
+        'CHECKED'    => $flag_checked,
+        'DISABLED'   => $flag_disabled,
+        'LINK_COLOR' => $flag_color,
+        'CURSOR'     => $flag_cursor,
+        'NAME'       => $group['name'],
+        )
+    );
+    $template->parse('group_list2', 'group_list_block2', true);
+}
 
+$template->set_block('main_block', 'page_list_block2', 'page_list2');
+if($admin->get_permission('pages_add_l0') == true) {
+    $template->set_var(array(
+            'ID'       => '0',
+            'TITLE'    => $TEXT['NONE'],
+            'SELECTED' => ' selected="selected"',
+            'DISABLED' => ''
+        )
+    );
+    $template->parse('page_list2', 'page_list_block2', true);
+}
+parent_list(0);
+
+// Explode module permissions
+$module_permissions = $_SESSION['MODULE_PERMISSIONS'];
+// Modules list
+$template->set_block('main_block', 'module_list_block', 'module_list');
+$result = $database->query("SELECT * FROM ".TABLE_PREFIX."addons WHERE type = 'module' AND function LIKE '%page%' order by name");
+if($result->numRows() > 0) {
+    while ($module = $result->fetchRow()) {
+        // Check if user is allowed to use this module
+        if(!is_numeric(array_search($module['directory'], $module_permissions))) {
+            $template->set_var('VALUE', $module['directory']);
+            $template->set_var('NAME', $admin->get_module_name($module['directory']));
+            if($module['directory'] == 'wysiwyg') {
+                $template->set_var('SELECTED', ' selected="selected"');
+            } else {
+                $template->set_var('SELECTED', '');
+            }
+            $template->parse('module_list', 'module_list_block', true);
+        }
+    }
+}
+
+// Insert urls
+$template->set_var(array(
+    'THEME_URL' => THEME_URL,
+    'WB_URL'    => WB_URL,
+    'WB_PATH'   => WB_PATH,
+    'ADMIN_URL' => ADMIN_URL,
+    // Insert language headings
+    'HEADING_ADD_PAGE'          => $HEADING['ADD_PAGE'],
+    'HEADING_MODIFY_INTRO_PAGE' => $HEADING['MODIFY_INTRO_PAGE'],
+    // Insert language text and messages
+    'TEXT_PAGES'              => $MENU['PAGES'],
+    'TEXT_TITLE'              => $TEXT['TITLE'],
+    'TEXT_TYPE'               => $TEXT['TYPE'],
+    'TEXT_PARENT'             => $TEXT['PARENT'],
+    'TEXT_VISIBILITY'         => $TEXT['VISIBILITY'],
+    'TEXT_PUBLIC'             => $TEXT['PUBLIC'],
+    'TEXT_PRIVATE'            => $TEXT['PRIVATE'],
+    'TEXT_REGISTERED'         => $TEXT['REGISTERED'],
+    'TEXT_HIDDEN'             => $TEXT['HIDDEN'],
+    'TEXT_NONE'               => $TEXT['NONE'],
+    'TEXT_NONE_FOUND'         => $TEXT['NONE_FOUND'],
+    'TEXT_ADD'                => $TEXT['ADD'],
+    'TEXT_RESET'              => $TEXT['RESET'],
+    'TEXT_ADMINISTRATORS'     => $TEXT['ADMINISTRATORS'],
+    'TEXT_PRIVATE_VIEWERS'    => $TEXT['PRIVATE_VIEWERS'],
+    'TEXT_REGISTERED_VIEWERS' => $TEXT['REGISTERED_VIEWERS'],
+    'INTRO_LINK'              => $MESSAGE['PAGES_INTRO_LINK'],
+    )
+);
+
+// Insert permissions values
+if($admin->get_permission('pages_add') != true) {
+    $template->set_var('DISPLAY_ADD', 'hide');
+} elseif($admin->get_permission('pages_add_l0') != true AND $editable_pages == 0) {
+    $template->set_var('DISPLAY_ADD', 'hide');
+}
+if($admin->get_permission('pages_intro') != true OR INTRO_PAGE != 'enabled') {
+    $template->set_var('DISPLAY_INTRO', 'hide');
+}
+
+// Include JavaScript backend includes and define output
+ob_start();
+$jsadminFile = WB_PATH.'/modules/jsadmin/jsadmin_backend_include.php';
+if(is_file($jsadminFile)) include($jsadminFile);
+$jsAdminOutput = ob_get_clean();
+
+// Oadd eggsurplus Javascript to output
+$jsAdminOutput .= PHP_EOL . '<script type="text/javascript" src="eggsurplus.js"></script>';
+
+// Set JavaScript backend as var
+$template->set_var('JS_ADMIN', $jsAdminOutput);
+
+// Parse template object
+$template->parse('main', 'main_block', false);
+$template->pparse('output', 'page');
+
+// Print admin
+$admin->print_footer();
+
+// Functions 
 // Parent page list
-// $database = new database();
 function parent_list($parent){
     global $admin, $database, $template, $field_set;
     $query = "SELECT * FROM ".TABLE_PREFIX."pages WHERE parent = '$parent' AND visibility!='deleted' ORDER BY position ASC";
@@ -168,130 +254,30 @@ function parent_list($parent){
                     $in_group = TRUE;
                 }
             }
-			if(($in_group) OR is_numeric(array_search($admin->get_user_id(), $admin_users))) {
+            if(($in_group) OR is_numeric(array_search($admin->get_user_id(), $admin_users))) {
                 $can_modify = true;
             } else {
                 $can_modify = false;
             }
             // Title -'s prefix
             $title_prefix = '';
-			for($i = 1; $i <= $page['level']; $i++) { $title_prefix .= ' - '; }
-                $template->set_var(array(
-                                        'ID' => $page['page_id'],
-                                        'TITLE' => ($title_prefix.$page['menu_title']),
-                                        'MENU-TITLE' => ($title_prefix.$page['menu_title']),
-                                        'PAGE-TITLE' => ($title_prefix.$page['page_title'])
-					)
-				);
-                if($can_modify == true) {
-                    $template->set_var('DISABLED', '');
-                } else {
-                    $template->set_var('DISABLED', ' disabled="disabled" class="disabled"');
-                }
-                $template->parse('page_list2', 'page_list_block2', true);
+            for($i = 1; $i <= $page['level']; $i++) { 
+                $title_prefix .= ' - ';                 
+            }
+            $template->set_var(array(
+                'ID'         => $page['page_id'],
+                'TITLE'      => ($title_prefix.$page['menu_title']),
+                'MENU-TITLE' => ($title_prefix.$page['menu_title']),
+                'PAGE-TITLE' => ($title_prefix.$page['page_title'])
+                )
+            );
+            if($can_modify == true) {
+                $template->set_var('DISABLED', '');
+            } else {
+                $template->set_var('DISABLED', ' disabled="disabled" class="disabled"');
+            }
+            $template->parse('page_list2', 'page_list_block2', true);
         }
         parent_list($page['page_id']);
     }
 }
-$template->set_block('main_block', 'page_list_block2', 'page_list2');
-if($admin->get_permission('pages_add_l0') == true) {
-    $template->set_var(array(
-                        'ID' => '0',
-                        'TITLE' => $TEXT['NONE'],
-                        'SELECTED' => ' selected="selected"',
-                        'DISABLED' => ''
-                    )
-                );
-    $template->parse('page_list2', 'page_list_block2', true);
-}
-parent_list(0);
-
-// Explode module permissions
-$module_permissions = $_SESSION['MODULE_PERMISSIONS'];
-// Modules list
-$template->set_block('main_block', 'module_list_block', 'module_list');
-$result = $database->query("SELECT * FROM ".TABLE_PREFIX."addons WHERE type = 'module' AND function LIKE '%page%' order by name");
-if($result->numRows() > 0) {
-    while ($module = $result->fetchRow()) {
-        // Check if user is allowed to use this module
-        if(!is_numeric(array_search($module['directory'], $module_permissions))) {
-            $template->set_var('VALUE', $module['directory']);
-            $template->set_var('NAME', $module['name']);
-            if($module['directory'] == 'wysiwyg') {
-                $template->set_var('SELECTED', ' selected="selected"');
-            } else {
-                $template->set_var('SELECTED', '');
-            }
-            $template->parse('module_list', 'module_list_block', true);
-        }
-    }
-}
-
-// Insert urls
-$template->set_var(array(
-                                'THEME_URL' => THEME_URL,
-                                'WB_URL' => WB_URL,
-	'WB_PATH' => WB_PATH,
-                                'ADMIN_URL' => ADMIN_URL,
-                                )
-                        );
-
-// Insert language headings
-$template->set_var(array(
-                                'HEADING_ADD_PAGE' => $HEADING['ADD_PAGE'],
-                                'HEADING_MODIFY_INTRO_PAGE' => $HEADING['MODIFY_INTRO_PAGE']
-                                )
-                        );
-// Insert language text and messages
-$template->set_var(array(
-								'TEXT_PAGES' => $MENU['PAGES'],
-                                'TEXT_TITLE' => $TEXT['TITLE'],
-                                'TEXT_TYPE' => $TEXT['TYPE'],
-                                'TEXT_PARENT' => $TEXT['PARENT'],
-                                'TEXT_VISIBILITY' => $TEXT['VISIBILITY'],
-                                'TEXT_PUBLIC' => $TEXT['PUBLIC'],
-                                'TEXT_PRIVATE' => $TEXT['PRIVATE'],
-                                'TEXT_REGISTERED' => $TEXT['REGISTERED'],
-                                'TEXT_HIDDEN' => $TEXT['HIDDEN'],
-                                'TEXT_NONE' => $TEXT['NONE'],
-                                'TEXT_NONE_FOUND' => $TEXT['NONE_FOUND'],
-                                'TEXT_ADD' => $TEXT['ADD'],
-                                'TEXT_RESET' => $TEXT['RESET'],
-                                'TEXT_ADMINISTRATORS' => $TEXT['ADMINISTRATORS'],
-                                'TEXT_PRIVATE_VIEWERS' => $TEXT['PRIVATE_VIEWERS'],
-                                'TEXT_REGISTERED_VIEWERS' => $TEXT['REGISTERED_VIEWERS'],
-                                'INTRO_LINK' => $MESSAGE['PAGES_INTRO_LINK'],
-                                )
-                        );
-
-// Insert permissions values
-if($admin->get_permission('pages_add') != true) {
-    $template->set_var('DISPLAY_ADD', 'hide');
-} elseif($admin->get_permission('pages_add_l0') != true AND $editable_pages == 0) {
-    $template->set_var('DISPLAY_ADD', 'hide');
-}
-if($admin->get_permission('pages_intro') != true OR INTRO_PAGE != 'enabled') {
-    $template->set_var('DISPLAY_INTRO', 'hide');
-}
-
-// Include JavaScript backend includes and define output
-ob_start();
-$jsadminFile = WB_PATH.'/modules/jsadmin/jsadmin_backend_include.php';
-if(is_file($jsadminFile)) {
-	include($jsadminFile);
-}
-$jsAdminOutput = ob_get_clean();
-
-// Oadd eggsurplus Javascript to output
-$jsAdminOutput .= PHP_EOL . '<script type="text/javascript" src="eggsurplus.js"></script>';
-
-// Set JavaScript backend as var
-$template->set_var('JS_ADMIN', $jsAdminOutput);
-
-// Parse template object
-$template->parse('main', 'main_block', false);
-$template->pparse('output', 'page');
-
-// Print admin
-$admin->print_footer();
-?>

--- a/wbce/admin/pages/modify.php
+++ b/wbce/admin/pages/modify.php
@@ -47,142 +47,131 @@ $modified_ts = ($results_array['modified_when'] != 0) ? $modified_ts = date(TIME
 // $ftan_module = $GLOBALS['ftan_module'];
 // Setup template object, parse vars to it, then parse it
 // Create new template object
-$pageModifyTemplate = new Template(dirname($admin->correct_theme_source('pages_modify.htt')));
+$oTemplate = new Template(dirname($admin->correct_theme_source('pages_modify.htt')));
 						
 // Disable removing of unknown vars to prevent the deleting of JavaScript arrays [] or {}
-$pageModifyTemplate->set_unknowns('keep');
+$oTemplate->set_unknowns('keep');
 
-// $pageModifyTemplate->debug = true;
-$pageModifyTemplate->set_file('page', 'pages_modify.htt');
-$pageModifyTemplate->set_block('page', 'main_block', 'main');
-$pageModifyTemplate->set_var('FTAN', $admin->getFTAN());
+// $oTemplate->debug = true;
+$oTemplate->set_file('page', 'pages_modify.htt');
+$oTemplate->set_block('page', 'main_block', 'main');
+$oTemplate->set_var('FTAN', $admin->getFTAN());
 
-$pageModifyTemplate->set_var(array(
-    'PAGE_ID' => $results_array['page_id'],
-    // 'PAGE_IDKEY' => $admin->getIDKEY($results_array['page_id']),
-    'PAGE_IDKEY' => $results_array['page_id'],
-    'PAGE_TITLE' => ($results_array['page_title']),
-    'MENU_TITLE' => ($results_array['menu_title']),
-    'ADMIN_URL' => ADMIN_URL,
-    'WB_URL' => WB_URL,
-    'THEME_URL' => THEME_URL
-));
-
-$pageModifyTemplate->set_var(array(
-    'MODIFIED_BY' => $user['display_name'],
-    'MODIFIED_BY_USERNAME' => $user['username'],
+$oTemplate->set_var(array(
+    'ADMIN_URL'     => ADMIN_URL,
+    'WB_URL'        => WB_URL,
+    'THEME_URL'     => THEME_URL,
+    'PAGE_ID'       => $results_array['page_id'],
+    'PAGE_IDKEY'    => $results_array['page_id'],
+    'PAGE_TITLE'    => $results_array['page_title'],
+    'MENU_TITLE'    => $results_array['menu_title'],
+    'MODIFIED_BY'   => $user['display_name'],
     'MODIFIED_WHEN' => $modified_ts,
     'LAST_MODIFIED' => $MESSAGE['PAGES_LAST_MODIFIED'],
+    'MODIFIED_BY_USERNAME' => $user['username'],
+    // Language Strings
+    'TEXT_CURRENT_PAGE'    => $TEXT['CURRENT_PAGE'],
+    'TEXT_CHANGE_SETTINGS' => $TEXT['CHANGE_SETTINGS'],
+    'HEADING_MODIFY_PAGE'  => $HEADING['MODIFY_PAGE'],
+    'TEXT_MANAGE_SECTIONS' => $HEADING['MANAGE_SECTIONS'],
 ));
 
-$pageModifyTemplate->set_block('main_block', 'show_modify_block', 'show_modify');
+$oTemplate->set_block('main_block', 'show_modify_block', 'show_modify');
 if ($modified_ts == 'Unknown') {
-    $pageModifyTemplate->set_block('show_modify', '');
-    $pageModifyTemplate->set_var('CLASS_DISPLAY_MODIFIED', 'hide');
+    $oTemplate->set_block('show_modify', '');
+    $oTemplate->set_var('CLASS_DISPLAY_MODIFIED', 'hide');
 } else {
-    $pageModifyTemplate->set_var('CLASS_DISPLAY_MODIFIED', '');
-    $pageModifyTemplate->parse('show_modify', 'show_modify_block', true);
+    $oTemplate->set_var('CLASS_DISPLAY_MODIFIED', '');
+    $oTemplate->parse('show_modify', 'show_modify_block', true);
 }
 
 // Work-out if we should show the "manage sections" link
-$sql = 'SELECT COUNT(*) FROM `' . TABLE_PREFIX . 'sections` '
-        . 'WHERE `page_id`=' . (int) $page_id . ' AND `module`=\'menu_link\'';
-$query_sections = $database->get_one($sql);
+$sSql = "SELECT COUNT(*) FROM `{TP}sections` WHERE `page_id`=".$page_id." AND `module`='menu_link'";
+$rQueryMenuLink = $database->get_one($sSql);
 
-$pageModifyTemplate->set_block('main_block', 'show_section_block', 'show_section');
-if ($query_sections) {
-    $pageModifyTemplate->set_block('show_section', '');
-    $pageModifyTemplate->set_var('DISPLAY_MANAGE_SECTIONS', 'display:none;');
+$oTemplate->set_block('main_block', 'show_section_block', 'show_section');
+if ($rQueryMenuLink) {
+    $oTemplate->set_block('show_section', '');
+    $oTemplate->set_var('DISPLAY_MANAGE_SECTIONS', 'display:none;');
 } elseif (MANAGE_SECTIONS == 'enabled') {
-    $pageModifyTemplate->set_var('TEXT_MANAGE_SECTIONS', $HEADING['MANAGE_SECTIONS']);
-    $pageModifyTemplate->parse('show_section', 'show_section_block', true);
+    $oTemplate->parse('show_section', 'show_section_block', true);
 } else {
-    $pageModifyTemplate->set_block('show_section', '');
-    $pageModifyTemplate->set_var('DISPLAY_MANAGE_SECTIONS', 'display:none;');
+    $oTemplate->set_block('show_section', '');
+    $oTemplate->set_var('DISPLAY_MANAGE_SECTIONS', 'display:none;');
 }
 
-// Insert language TEXT
-$pageModifyTemplate->set_var(array(
-    'TEXT_CURRENT_PAGE' => $TEXT['CURRENT_PAGE'],
-    'TEXT_CHANGE_SETTINGS' => $TEXT['CHANGE_SETTINGS'],
-    'HEADING_MODIFY_PAGE' => $HEADING['MODIFY_PAGE']
-));
-
-$pageModifyTemplate->set_block('main_block', 'section_module_block', 'section_module');
-
+$oTemplate->set_block('main_block', 'section_module_block', 'section_module');
 // get template used for the displayed page (for displaying block details)
 if (SECTION_BLOCKS) {
-    $sql = 'SELECT `template` FROM `' . TABLE_PREFIX . 'pages` '
-            . 'WHERE `page_id`=' . (int) $page_id;
-    if (($sTemplate = $database->get_one($sql)) !== null) {
-        $page_template = ($sTemplate == '') ? DEFAULT_TEMPLATE : $sTemplate;
-
-        // include template info file if exists
-        if (is_readable(WB_PATH . '/templates/' . $page_template . '/info.php')) {
-            include_once(WB_PATH . '/templates/' . $page_template . '/info.php');
-        }
+    $sSql = 'SELECT `template` FROM `{TP}pages` WHERE `page_id`=' . (int) $page_id;
+    if (($sTemplate = $database->get_one($sSql)) !== null) {
+        $sPageTemplate = ($sTemplate == '') ? DEFAULT_TEMPLATE : $sTemplate;
+        // include template info.php file if exists
+        $sFile = WB_PATH . '/templates/' . $sPageTemplate . '/info.php';
+        if (is_readable($sFile)) include_once $sFile;
     }
 }
 
 // Get sections for this page
-$module_permissions = $_SESSION['MODULE_PERMISSIONS'];
-// workout for edit only one section for faster pageloading
-// Constant later set in wb_settings, in meantime defined in framework/initialize.php
-$sql = 'SELECT * FROM `' . TABLE_PREFIX . 'sections` ';
-$sql .= (defined('EDIT_ONE_SECTION') && EDIT_ONE_SECTION && is_numeric($sectionId)) ? 'WHERE `section_id` = ' . $sectionId : 'WHERE `page_id` = ' . intval($page_id);
-$sql .= ' ORDER BY position ASC';
-$query_sections = $database->query($sql);
-if ($query_sections->numRows() > 0) {
+// workout for EDIT_ONE_SECTION for faster pageloading
+$sWhereClause = (defined('EDIT_ONE_SECTION') && EDIT_ONE_SECTION && is_numeric($sectionId)) 
+        ? 'WHERE `section_id` = ' . (int) $sectionId 
+        : 'WHERE `page_id` = ' . (int) $page_id;
+$sSql = 'SELECT * FROM `{TP}sections` '.$sWhereClause.' ORDER BY position ASC';
+if($rSections = $database->query($sSql)){
 	
-    while ($section = $query_sections->fetchRow()) {
+    while ($section = $rSections->fetchRow(MYSQL_ASSOC)) {
         $section_id = $section['section_id'];
         $module = $section['module'];
 
         //Have permission?
-        if (!is_numeric(array_search($module, $module_permissions))) {
+        if (!is_numeric(array_search($module, $_SESSION['MODULE_PERMISSIONS']))) {
             // Include the modules editing script if it exists
-            if (file_exists(WB_PATH . '/modules/' . $module . '/modify.php')) {
+            $sModifyFile = WB_PATH . '/modules/' . $module . '/modify.php';
+            if (file_exists($sModifyFile)) {
 
-                    // Define section block name
-                    if (isset($block[$section['block']]) && trim(strip_tags(($block[$section['block']]))) != '') {
-                        $blockName = htmlentities(strip_tags($block[$section['block']]));
-                    } else {
-                        $blockName = '#' . (int) $section['block'];
-                        if ($section['block'] == 1) {
-                            $blockName = $TEXT['MAIN'];
-                        }
+                // Define section block name
+                if (isset($block[$section['block']]) && trim(strip_tags(($block[$section['block']]))) != '') {
+                    $sBlockName = htmlentities(strip_tags($block[$section['block']]));
+                } else {
+                    $sBlockName = '#' . (int) $section['block'];
+                    if ($section['block'] == 1) {
+                        $sBlockName = $TEXT['MAIN'];
                     }
+                }
 
-                    // Define section anchor
-                    $sectionAnchor = (defined('SEC_ANCHOR') && SEC_ANCHOR ? SEC_ANCHOR . $section['section_id'] : '');
+                // Define section anchor
+                // We definitely need a section anchor in the Backend (no matter if it's set to empty for the Frontend)
+                // Therefore, if SEC_ANCHOR is empty, in the backend we will use 'sec_anchor_' instead.
+                $sSectionAnchor = (defined('SEC_ANCHOR') && SEC_ANCHOR ? SEC_ANCHOR : 'sec_anchor_') . $section['section_id'];
 
-                    // Set template vars
-                    $pageModifyTemplate->set_var('SECTION_ANCHOR', $sectionAnchor);
-                    $pageModifyTemplate->set_var('TEXT_BLOCK', $TEXT['BLOCK']);
-                    $pageModifyTemplate->set_var('BLOCK_NAME', $blockName);
-                    $pageModifyTemplate->set_var('SECTION_ID', $section['section_id']);
-                    $pageModifyTemplate->set_var('SECTION_MODULE', $section['module']);
-                    $pageModifyTemplate->set_var('SECTION_BLOCK', $section['block']);
-                    $pageModifyTemplate->set_var('SECTION_NAME', $section['namesection']);
+                // Set template vars
+                $oTemplate->set_var(
+                    array(
+                        'SECTION_ANCHOR' => $sSectionAnchor, 
+                        'TEXT_BLOCK'     => $TEXT['BLOCK'], 
+                        'BLOCK_NAME'     => $sBlockName, 
+                        'SECTION_ID'     => $section['section_id'], 
+                        'SECTION_MODULE' => $admin->get_module_name($section['module']), 
+                        'SECTION_BLOCK'  => $section['block'], 
+                        'SECTION_NAME'   => $section['namesection'], 
+                    )
+                );
 
                 // Set section modify output as template var				
                 ob_start();
-                require(WB_PATH . '/modules/' . $module . '/modify.php');
-                $pageModifyTemplate->set_var('SECTION_MODIFY_OUTPUT', ob_get_clean());
-
+                require $sModifyFile;
+                $oTemplate->set_var('SECTION_MODIFY_OUTPUT', ob_get_clean());
                 // Parse section module
-                $pageModifyTemplate->parse('section_module', 'section_module_block', true);
-			
+                $oTemplate->parse('section_module', 'section_module_block', true);			
             }
         }
     }
-		
 }
 
 // Parse and print header template
-$pageModifyTemplate->parse('main', 'main_block', false);
-$pageModifyTemplate->pparse('output', 'page');
-
+$oTemplate->parse('main', 'main_block', false);
+$oTemplate->pparse('output', 'page');
 
 // Print admin footer
 $admin->print_footer();

--- a/wbce/admin/pages/sections.php
+++ b/wbce/admin/pages/sections.php
@@ -51,7 +51,7 @@ switch ($action) {
         }
 
         $action = 'show';
-        $sSql = 'SELECT `module` FROM `{TP}sections` WHERE `section_id` = '.$section_id;
+        $sSql = "SELECT `module` FROM `{TP}sections` WHERE `section_id` = ".$section_id;
         if ((($sModDir = $database->get_one($sSql)) == $module) && ($section_id > 0)) {
             // Include the modules delete file if it exists
             $sDeleteFile = WB_PATH . '/modules/' . $sModDir . '/delete.php';
@@ -121,7 +121,7 @@ switch ($action) {
         if ($admin_header) 
             $admin->print_header();
         // Get perms
-        $sSql = 'SELECT `admin_groups`,`admin_users` FROM `{TP}pages` WHERE `page_id` = '.$page_id;
+        $sSql = "SELECT `admin_groups`,`admin_users` FROM `{TP}pages` WHERE `page_id` = ".$page_id;
         $results = $database->query($sSql);
 
         $results_array = $results->fetchRow();
@@ -188,51 +188,52 @@ switch ($action) {
 
         // Setup template object, parse vars to it, then parse it
         // Create new template object
-        $tpl = new Template(dirname($admin->correct_theme_source('pages_sections.htt')));
-        $tpl->set_file('page', 'pages_sections.htt');
+        $oTemplate = new Template(dirname($admin->correct_theme_source('pages_sections.htt')));
+        $oTemplate->set_file('page', 'pages_sections.htt');
         
-        $tpl->set_block('page',          'main_block',     'main');
-        $tpl->set_block('main_block',    'module_block',   'module_list');
-        $tpl->set_block('main_block',    'section_block',  'section_list');
-        $tpl->set_block('section_block', 'block_block',    'block_list');
-        $tpl->set_block('main_block',    'calendar_block', 'calendar_list');
+        $oTemplate->set_block('page',          'main_block',     'main');
+        $oTemplate->set_block('main_block',    'module_block',   'module_list');
+        $oTemplate->set_block('main_block',    'section_block',  'section_list');
+        $oTemplate->set_block('section_block', 'block_block',    'block_list');
+        $oTemplate->set_block('main_block',    'calendar_block', 'calendar_list');
 
         // set first defaults and messages
-        $tpl->set_var(
+        $oTemplate->set_var(
             array(
-                'FTAN' => $admin->getFTAN(),
-                'PAGE_ID' => $aPage['page_id'],
-                'PAGE_IDKEY' => $aPage['page_id'],
-                'TEXT_PAGE' => $TEXT['PAGE'],
-                'PAGE_TITLE' => ($aPage['page_title']),
-                'MENU_TITLE' => ($aPage['menu_title']),
-                'TEXT_CURRENT_PAGE' => $TEXT['CURRENT_PAGE'],
-                'HEADING_MANAGE_SECTIONS' => $HEADING['MANAGE_SECTIONS'],
-                'HEADING_MODIFY_PAGE' => $HEADING['MODIFY_PAGE'],
-                'TEXT_CHANGE_SETTINGS' => $TEXT['CHANGE_SETTINGS'],
-                'TEXT_ADD_SECTION' => $TEXT['ADD_SECTION'],
-                'TEXT_ID' => 'ID',
-                'TEXT_TYPE' => $TEXT['TYPE'],
-                'TEXT_BLOCK' => $TEXT['BLOCK'],
-                'TEXT_NAMESECTION' => $TEXT['SECTION'] . ' ' . $TEXT['NAME'],
-                'TEXT_PUBL_START_DATE' => $TEXT{'PUBL_START_DATE'},
-                'TEXT_PUBL_END_DATE' => $TEXT['PUBL_END_DATE'],
+                'ADMIN_URL'    => ADMIN_URL,
+                'WB_URL'       => WB_URL,
+                'THEME_URL'    => THEME_URL,
+                'FTAN'         => $admin->getFTAN(),
+                'MODIFIED_BY'  => $user['display_name'],
+                'PAGE_ID'      => $aPage['page_id'],
+                'PAGE_IDKEY'   => $aPage['page_id'],
+                'TEXT_PAGE'    => $TEXT['PAGE'],
+                'PAGE_TITLE'   => ($aPage['page_title']),
+                'MENU_TITLE'   => ($aPage['menu_title']),
+                'TEXT_ID'      => 'ID',
+                'TEXT_TYPE'    => $TEXT['TYPE'],
+                'TEXT_BLOCK'   => $TEXT['BLOCK'],
                 'TEXT_ACTIONS' => $TEXT['ACTIONS'],
-                'TEXT_BACK' => $TEXT['BACK'],
-                'MODIFIED_BY' => $user['display_name'],
-                'MODIFIED_BY_USERNAME' => $user['username'],
-                'MODIFIED_WHEN' => $modified_ts,
-                'LAST_MODIFIED' => $MESSAGE['PAGES_LAST_MODIFIED'],
-                'ADMIN_URL' => ADMIN_URL,
-                'WB_URL' => WB_URL,
-                'THEME_URL' => THEME_URL,
-                'VAR_PAGE_TITLE' => $aPage['page_title'],
-                'SETTINGS_LINK' => ADMIN_URL . '/pages/settings.php?page_id=' . $aPage['page_id'],
-                'MODIFY_LINK' => ADMIN_URL . '/pages/modify.php?page_id=' . $aPage['page_id'],
+                'TEXT_BACK'    => $TEXT['BACK'],
+                
+                'TEXT_CURRENT_PAGE'       => $TEXT['CURRENT_PAGE'],
+                'HEADING_MANAGE_SECTIONS' => $HEADING['MANAGE_SECTIONS'],
+                'HEADING_MODIFY_PAGE'     => $HEADING['MODIFY_PAGE'],
+                'TEXT_CHANGE_SETTINGS'    => $TEXT['CHANGE_SETTINGS'],
+                'TEXT_ADD_SECTION'        => $TEXT['ADD_SECTION'],
+                'TEXT_NAMESECTION'        => $TEXT['SECTION'] . ' ' . $TEXT['NAME'],
+                'TEXT_PUBL_START_DATE'    => $TEXT{'PUBL_START_DATE'},
+                'TEXT_PUBL_END_DATE'      => $TEXT['PUBL_END_DATE'],
+                'MODIFIED_BY_USERNAME'    => $user['username'],
+                'MODIFIED_WHEN'           => $modified_ts,
+                'LAST_MODIFIED'           => $MESSAGE['PAGES_LAST_MODIFIED'],
+                'VAR_PAGE_TITLE'          => $aPage['page_title'],
+                'SETTINGS_LINK'           => ADMIN_URL . '/pages/settings.php?page_id=' . $aPage['page_id'],
+                'MODIFY_LINK'             => ADMIN_URL . '/pages/modify.php?page_id=' . $aPage['page_id'],
             )
         );
 
-        $sSql = 'SELECT * FROM `{TP}sections` WHERE `page_id` = '.$page_id.' ORDER BY `position` ASC';
+        $sSql = "SELECT * FROM `{TP}sections` WHERE `page_id` = ".$page_id." ORDER BY `position` ASC";
         $rSections = $database->query($sSql);
 
         $num_sections = $rSections->numRows();
@@ -240,7 +241,7 @@ switch ($action) {
             while ($section = $rSections->fetchRow()) {
                 if (!is_numeric(array_search($section['module'], $module_permissions))) {
                     // Get the modules real name
-                    $sSql = 'SELECT `name` FROM `{TP}addons` WHERE `directory` = "'.$section['module'].'"';
+                    $sSql = "SELECT `name` FROM `{TP}addons` WHERE `directory` = '".$section['module']."'";
                     if (!$database->get_one($sSql) || !file_exists(WB_PATH . '/modules/' . $section['module'])) {
                         $edit_page = '<span class="module_disabled">' . $section['module'] . '</span>';
                     } else {
@@ -249,7 +250,7 @@ switch ($action) {
                     $sec_anchor = (defined('SEC_ANCHOR') && (SEC_ANCHOR != '') ? SEC_ANCHOR : '');
                     $edit_page_0 = '<a id="sid' . $section['section_id'] . '" href="' . ADMIN_URL . '/pages/modify.php?page_id=' . $aPage['page_id'];
                     $edit_page_1 = ($sec_anchor != '') ? '#' . $sec_anchor . $section['section_id'] . '">' : '">';
-                    $edit_page_1 .= $section['module'] . '</a>';
+                    $edit_page_1 .= $admin->get_module_name($section['module']) . '</a>';
                     if (SECTION_BLOCKS) {
                         if ($edit_page == '') {
                             if (defined('EDIT_ONE_SECTION') && EDIT_ONE_SECTION) {
@@ -259,7 +260,7 @@ switch ($action) {
                             }
                         }
                         $input_attribute = 'input_normal';
-                        $tpl->set_var(
+                        $oTemplate->set_var(
                             array(
                                 'STYLE_DISPLAY_SECTION_BLOCK' => ' style="visibility:visible;"',
                                 'NAME_SIZE' => 300,
@@ -273,24 +274,24 @@ switch ($action) {
                             )
                         );
                         // Add block options to the section_list
-                        $tpl->clear_var('block_list');
+                        $oTemplate->clear_var('block_list');
                         foreach ($block as $number => $name) {
-                            $tpl->set_var('NAME', htmlentities(strip_tags($name)));
-                            $tpl->set_var('VALUE', $number);
-                            $tpl->set_var('SIZE', 1);
+                            $oTemplate->set_var('NAME', htmlentities(strip_tags($name)));
+                            $oTemplate->set_var('VALUE', $number);
+                            $oTemplate->set_var('SIZE', 1);
                             if ($section['block'] == $number) {
-                                $tpl->set_var('SELECTED', ' selected="selected"');
+                                $oTemplate->set_var('SELECTED', ' selected="selected"');
                             } else {
-                                $tpl->set_var('SELECTED', '');
+                                $oTemplate->set_var('SELECTED', '');
                             }
-                            $tpl->parse('block_list', 'block_block', true);
+                            $oTemplate->parse('block_list', 'block_block', true);
                         }
                     } else {
                         if ($edit_page == '') {
                             $edit_page = $edit_page_0 . '#wb_' . $edit_page_1;
                         }
                         $input_attribute = 'input_normal';
-                        $tpl->set_var(
+                        $oTemplate->set_var(
                             array(
                                 'STYLE_DISPLAY_SECTION_BLOCK' => ' style="visibility:hidden;"',
                                 'NAME_SIZE' => 300,
@@ -306,81 +307,84 @@ switch ($action) {
                         );
                     }
                     // named sections patch
-                    $tpl->set_var('NAMESECTION', $section['namesection']);
+                    $oTemplate->set_var('NAMESECTION', $section['namesection']);
                     // Insert icon and images
-                    $tpl->set_var(array(
-                        'CLOCK_16_PNG' => 'clock_16.png',
+                    $oTemplate->set_var(array(
+                        'CLOCK_16_PNG'     => 'clock_16.png',
                         'CLOCK_DEL_16_PNG' => 'clock_del_16.png',
-                        'DELETE_16_PNG' => 'delete_16.png',
+                        'DELETE_16_PNG'    => 'delete_16.png',
                     )
                     );
                     // set calendar start values
                     if ($section['publ_start'] == 0) {
-                        $tpl->set_var('VALUE_PUBL_START', '');
+                        $oTemplate->set_var('VALUE_PUBL_START', '');
                     } else {
-                        $tpl->set_var('VALUE_PUBL_START', date($jscal_format, $section['publ_start']));
+                        $oTemplate->set_var('VALUE_PUBL_START', date($jscal_format, $section['publ_start']));
                     }
                     // set calendar start values
                     if ($section['publ_end'] == 0) {
-                        $tpl->set_var('VALUE_PUBL_END', '');
+                        $oTemplate->set_var('VALUE_PUBL_END', '');
                     } else {
-                        $tpl->set_var('VALUE_PUBL_END', date($jscal_format, $section['publ_end']));
+                        $oTemplate->set_var('VALUE_PUBL_END', date($jscal_format, $section['publ_end']));
                     }
                     // Insert icons up and down
                     if ($section['position'] != 1) {
-                        $tpl->set_var(
+                        $oTemplate->set_var(
                             'VAR_MOVE_UP_URL',
                             '<a href="' . ADMIN_URL . '/pages/move_up.php?page_id=' . $page_id . '&amp;section_id=' . $section['section_id'] . '">
                             <img src="' . THEME_URL . '/images/up_16.png" alt="{TEXT_MOVE_UP}" />
                             </a>'
                         );
                     } else {
-                        $tpl->set_var('VAR_MOVE_UP_URL', '');
+                        $oTemplate->set_var('VAR_MOVE_UP_URL', '');
                     }
                     if ($section['position'] != $num_sections) {
-                        $tpl->set_var(
+                        $oTemplate->set_var(
                             'VAR_MOVE_DOWN_URL',
                             '<a href="' . ADMIN_URL . '/pages/move_down.php?page_id=' . $page_id . '&amp;section_id=' . $section['section_id'] . '">
                             <img src="' . THEME_URL . '/images/down_16.png" alt="{TEXT_MOVE_DOWN}" />
                             </a>'
                         );
                     } else {
-                        $tpl->set_var('VAR_MOVE_DOWN_URL', '');
+                        $oTemplate->set_var('VAR_MOVE_DOWN_URL', '');
                     }
                 } else {
                     continue;
                 }
 
-                $tpl->set_var(array(
-                    'DISPLAY_DEBUG'      => ' style="visibility="visible;"',
-                    'TEXT_SID'           => 'SID',
-                    'DEBUG_COLSPAN_SIZE' => 9,
-                )
+                $oTemplate->set_var(
+                    array(
+                        'DISPLAY_DEBUG'      => ' style="visibility="visible;"',
+                        'TEXT_SID'           => 'SID',
+                        'DEBUG_COLSPAN_SIZE' => 9,
+                    )
                 );
                 if ($debug) {
-                    $tpl->set_var(array(
-                        'DISPLAY_DEBUG' => ' style="visibility="visible;"',
-                        'TEXT_PID'      => 'PID',
-                        'TEXT_SID'      => 'SID',
-                        'POSITION'      => $section['position'],
-                    )
+                    $oTemplate->set_var(
+                        array(
+                            'DISPLAY_DEBUG' => ' style="visibility="visible;"',
+                            'TEXT_PID'      => 'PID',
+                            'TEXT_SID'      => 'SID',
+                            'POSITION'      => $section['position'],
+                        )
                     );
                 } else {
-                    $tpl->set_var(array(
-                        'DISPLAY_DEBUG' => ' style="display:none;"',
-                        'TEXT_PID'      => '',
-                        'POSITION'      => '',
-                    )
+                    $oTemplate->set_var(
+                        array(
+                            'DISPLAY_DEBUG' => ' style="display:none;"',
+                            'TEXT_PID'      => '',
+                            'POSITION'      => '',
+                        )
                     );
                 }
-                $tpl->parse('section_list', 'section_block', true);
+                $oTemplate->parse('section_list', 'section_block', true);
             }
         }
 
         // Now add the calendars -- remember to set the range to [1970, 2037] if the date is used as timestamp!
         // The loop is simply a copy from above.
-        $sSql = 'SELECT `section_id`,`module` FROM `{TP}sections` WHERE page_id = ' . $page_id . ' ';
-        $sSql .= 'ORDER BY `position` ASC';
+        $sSql = "SELECT `section_id`,`module` FROM `{TP}sections`   
+                    WHERE page_id = ".$page_id." ORDER BY `position` ASC";
         $rSections = $database->query($sSql);
 
         $num_sections = $rSections->numRows();
@@ -391,7 +395,7 @@ switch ($action) {
                 $module_name = $database->get_one($sSql);
 
                 if (!is_numeric(array_search($section['module'], $module_permissions))) {
-                    $tpl->set_var(array(
+                    $oTemplate->set_var(array(
                         'jscal_ifformat' => $jscal_ifformat,
                         'jscal_firstday' => $jscal_firstday,
                         'jscal_today'    => $jscal_today,
@@ -404,34 +408,34 @@ switch ($action) {
                         )
                     );
                 }
-                $tpl->parse('calendar_list', 'calendar_block', true);
+                $oTemplate->parse('calendar_list', 'calendar_block', true);
             }
         }
 
         // Work-out if we should show the "Add Section" form
       
-        $sSql = 'SELECT `section_id` FROM `{TP}sections` ';
-        $sSql .= 'WHERE `page_id` = ' . $page_id . ' AND `module` = "menu_link"';
+        $sSql = "SELECT `section_id` FROM `{TP}sections` WHERE `page_id` = ".$page_id." AND `module` = 'menu_link'";
         $rSections = $database->query($sSql);
         if ($rSections->numRows() == 0) {
             // Modules list
-            $sSql = 'SELECT `name`,`directory`,`type` FROM `{TP}addons` ';
-            $sSql .= 'WHERE `type` = "module" AND `function` = "page" AND `directory` != "menu_link" ';
-            $sSql .= 'ORDER BY `name`';
+            $sSql = "SELECT `name`,`directory`,`type` FROM `{TP}addons` 
+                        WHERE `type` = 'module' AND `function` = 'page' 
+                        AND `directory` != 'menu_link' 
+                        ORDER BY `name`";
             $rResult = $database->query($sSql);
             
             if ($rResult->numRows() > 0) {
                 while ($module = $rResult->fetchRow()) {
                     // Check if user is allowed to use this module   echo  $module['directory'],'<br />';
                     if (!is_numeric(array_search($module['directory'], $module_permissions))) {
-                        $tpl->set_var('VALUE', $module['directory']);
-                        $tpl->set_var('NAME', $admin->get_module_name($module['name']));
+                        $oTemplate->set_var('VALUE', $module['directory']);
+                        $oTemplate->set_var('NAME', $admin->get_module_name($module['directory']));
                         if ($module['directory'] == 'wysiwyg') {
-                            $tpl->set_var('SELECTED', ' selected="selected"');
+                            $oTemplate->set_var('SELECTED', ' selected="selected"');
                         } else {
-                            $tpl->set_var('SELECTED', '');
+                            $oTemplate->set_var('SELECTED', '');
                         }
-                        $tpl->parse('module_list', 'module_block', true);
+                        $oTemplate->parse('module_list', 'module_block', true);
                     } else {
                         continue;
                     }
@@ -439,7 +443,7 @@ switch ($action) {
             }
         }
         // Insert language text and messages
-        $tpl->set_var(
+        $oTemplate->set_var(
             array(
                 'TEXT_MANAGE_SECTIONS' => $HEADING['MANAGE_SECTIONS'],
                 'TEXT_ARE_YOU_SURE' => $TEXT['ARE_YOU_SURE'],
@@ -457,12 +461,11 @@ switch ($action) {
                 'MODIFIED_WHEN' => $modified_ts,
             )
         );
-        $tpl->parse('main', 'main_block', false);
-        $tpl->pparse('output', 'page');
+        $oTemplate->parse('main', 'main_block', false);
+        $oTemplate->pparse('output', 'page');
         // include the required file for Javascript admin
-        if (file_exists(WB_PATH . '/modules/jsadmin/jsadmin_backend_include.php')) {
-            include WB_PATH . '/modules/jsadmin/jsadmin_backend_include.php';
-        }
+        $sFile = WB_PATH . '/modules/jsadmin/jsadmin_backend_include.php';
+        if (file_exists($sFile)) include $sFile;
         break;
 }
 

--- a/wbce/admin/pages/sections.php
+++ b/wbce/admin/pages/sections.php
@@ -18,7 +18,7 @@ if (MANAGE_SECTIONS != 'enabled') {
     header('Location: ' . ADMIN_URL . '/pages/index.php');
     exit(0);
 }
-/* */
+
 $debug = false; // to show position and section_id
 if (!defined('DEBUG')) {define('DEBUG', $debug);}
 // Include the WB functions file
@@ -34,14 +34,14 @@ $page_id = intval((isset(${$requestMethod}['page_id'])) ? ${$requestMethod}['pag
 $action = ($page_id ? 'show' : $action);
 // Get section id if there is one
 $requestMethod = '_' . strtoupper($_SERVER['REQUEST_METHOD']);
-$section_id = ((isset(${$requestMethod}['section_id'])) ? ${$requestMethod}['section_id'] : 0);
+$section_id = ((isset(${$requestMethod}['section_id'])) ? (int) ${$requestMethod}['section_id'] : 0);
 $action = ($section_id ? 'delete' : $action);
 // Get module if there is one
 $requestMethod = '_' . strtoupper($_SERVER['REQUEST_METHOD']);
 $module = ((isset(${$requestMethod}['module'])) ? ${$requestMethod}['module'] : 0);
 $action = ($module != '' ? 'add' : $action);
 $admin_header = true;
-$backlink = ADMIN_URL . '/pages/sections.php?page_id=' . (int) $page_id;
+$backlink = ADMIN_URL . '/pages/sections.php?page_id=' . $page_id;
 
 switch ($action) {
     case 'delete':
@@ -51,25 +51,25 @@ switch ($action) {
         }
 
         $action = 'show';
-        $sql = 'SELECT `module` FROM `' . TABLE_PREFIX . 'sections` ';
-        $sql .= 'WHERE `section_id` =' . $section_id;
-        if ((($modulname = $database->get_one($sql)) == $module) && ($section_id > 0)) {
+        $sSql = 'SELECT `module` FROM `{TP}sections` WHERE `section_id` = '.$section_id;
+        if ((($sModDir = $database->get_one($sSql)) == $module) && ($section_id > 0)) {
             // Include the modules delete file if it exists
-            if (file_exists(WB_PATH . '/modules/' . $modulname . '/delete.php')) {
-                require WB_PATH . '/modules/' . $modulname . '/delete.php';
-            }
-            $sql = 'DELETE FROM `' . TABLE_PREFIX . 'sections` ';
-            $sql .= 'WHERE `section_id` =' . (int) $section_id . ' LIMIT 1';
-            if (!$database->query($sql)) {
-                if ($admin_header) {$admin->print_header();}
+            $sDeleteFile = WB_PATH . '/modules/' . $sModDir . '/delete.php';
+            if (file_exists($sDeleteFile)) 
+                require $sDeleteFile;
+            $sSql = 'DELETE FROM `{TP}sections` WHERE `section_id` = '.$section_id.' LIMIT 1';
+            if (!$database->query($sSql)) {
+                if ($admin_header) 
+                    $admin->print_header(); 
                 $admin->print_error($database->get_error(), $backlink);
             } else {
                 require_once WB_PATH . '/framework/class.order.php';
-                $order = new order(TABLE_PREFIX . 'sections', 'position', 'section_id', 'page_id');
+                $order = new order('{TP}sections', 'position', 'section_id', 'page_id');
                 $order->clean($page_id);
                 $format = $TEXT['SECTION'] . ' %d  %s %s ' . strtolower($TEXT['DELETED']);
                 $message = sprintf($format, $section_id, strtoupper($modulname), strtolower($TEXT['SUCCESS']));
-                if ($admin_header) {$admin->print_header();}
+                if ($admin_header) 
+                    $admin->print_header();
                 $admin_header = false;
                 unset($_POST);
                 $admin->print_success($message, $backlink);
@@ -89,23 +89,25 @@ switch ($action) {
         $module = preg_replace('/\W/', '', $module); // fix secunia 2010-91-4
         require_once WB_PATH . '/framework/class.order.php';
         // Get new order
-        $order = new order(TABLE_PREFIX . 'sections', 'position', 'section_id', 'page_id');
+        $order = new order('{TP}sections', 'position', 'section_id', 'page_id');
         $position = $order->get_new($page_id);
         // Insert module into DB
-        $sql = 'INSERT INTO `' . TABLE_PREFIX . 'sections` SET ';
-        $sql .= '`page_id` = ' . (int) $page_id . ', ';
-        $sql .= '`module` = \'' . $module . '\', ';
-        $sql .= '`position` = ' . (int) $position . ', ';
-        $sql .= '`block` = 1';
-        if ($database->query($sql)) {
+        $aInsert = array(
+            'page_id'  => (int) $page_id,
+            'module'   => $module,
+            'position' => (int) $position,
+            'block'    => 1,
+        );
+        if ($database->insertRow('{TP}section', $aInsert)) {
             // Get the section id
             $section_id = $database->get_one("SELECT LAST_INSERT_ID()");
             // Include the selected modules add file if it exists
-            if (file_exists(WB_PATH . '/modules/' . $module . '/add.php')) {
-                require WB_PATH . '/modules/' . $module . '/add.php';
-            }
+            $sAddFile = WB_PATH . '/modules/' . $module . '/add.php';
+            if (file_exists($sAddFile)) 
+                require $sAddFile;
         } elseif ($database->is_error()) {
-            if ($admin_header) {$admin->print_header();}
+            if ($admin_header) 
+                $admin->print_header();
             $admin->print_error($database->get_error());
         }
         break;
@@ -116,15 +118,15 @@ switch ($action) {
 
 switch ($action) {
     default:
-        if ($admin_header) {$admin->print_header();}
+        if ($admin_header) 
+            $admin->print_header();
         // Get perms
-        $sql = 'SELECT `admin_groups`,`admin_users` FROM `' . TABLE_PREFIX . 'pages` ';
-        $sql .= 'WHERE `page_id` = ' . $page_id;
-        $results = $database->query($sql);
+        $sSql = 'SELECT `admin_groups`,`admin_users` FROM `{TP}pages` WHERE `page_id` = '.$page_id;
+        $results = $database->query($sSql);
 
         $results_array = $results->fetchRow();
         $old_admin_groups = explode(',', $results_array['admin_groups']);
-        $old_admin_users = explode(',', $results_array['admin_users']);
+        $old_admin_users  = explode(',', $results_array['admin_users']);
         $in_old_group = false;
         foreach ($admin->get_groups_id() as $cur_gid) {
             if (in_array($cur_gid, $old_admin_groups)) {
@@ -137,19 +139,17 @@ switch ($action) {
         }
 
         // Get page details
-        $sql = 'SELECT * FROM `' . TABLE_PREFIX . 'pages` ';
-        $sql .= 'WHERE `page_id` = ' . $page_id;
-        $results = $database->query($sql);
+        $rPageDetails = $database->query('SELECT * FROM `{TP}pages` WHERE `page_id` = '.$page_id);
 
         if ($database->is_error()) {
             // $admin->print_header();
             $admin->print_error($database->get_error());
         }
-        if ($results->numRows() == 0) {
+        if ($rPageDetails->numRows() == 0) {
             // $admin->print_header();
             $admin->print_error($MESSAGE['PAGES_NOT_FOUND']);
         }
-        $results_array = $results->fetchRow();
+        $aPage = $rPageDetails->fetchRow();
 
         // Set module permissions
         $module_permissions = $_SESSION['MODULE_PERMISSIONS'];
@@ -157,8 +157,8 @@ switch ($action) {
         // Unset block var
         unset($block);
         // Include template info file (if it exists)
-        if ($results_array['template'] != '') {
-            $template_location = WB_PATH . '/templates/' . $results_array['template'] . '/info.php';
+        if ($aPage['template'] != '') {
+            $template_location = WB_PATH . '/templates/' . $aPage['template'] . '/info.php';
         } else {
             $template_location = WB_PATH . '/templates/' . DEFAULT_TEMPLATE . '/info.php';
         }
@@ -171,95 +171,83 @@ switch ($action) {
             $block[1] = $TEXT['MAIN'];
         }
 
-        /*-- load css files with jquery --*/
-                                // include jscalendar-setup
-        $jscal_use_time = true; // whether to use a clock, too
+        // Load css files with jquery 
+        // Include jscalendar-setup
+        $jscal_use_time = true; // tell to use a clock, too
         require_once WB_PATH . "/include/jscalendar/wb-setup.php";
 
         // Get display name of person who last modified the page
-		$user=$admin->get_user_details($results_array['modified_by']);
+        $user = $admin->get_user_details($aPage['modified_by']);
 
-		// Convert the unix ts for modified_when to human a readable form
-		if($results_array['modified_when'] != 0) {
-			$modified_ts = gmdate(TIME_FORMAT.', '.DATE_FORMAT, $results_array['modified_when']+TIMEZONE);
-		} else {
-			$modified_ts = 'Unknown';
-		}
+        // Convert the unix ts for modified_when to human a readable form
+        if($aPage['modified_when'] != 0) {
+            $modified_ts = gmdate(TIME_FORMAT.', '.DATE_FORMAT, $aPage['modified_when']+TIMEZONE);
+        } else {
+            $modified_ts = 'Unknown';
+        }
 
-		// Setup template object, parse vars to it, then parse it
+        // Setup template object, parse vars to it, then parse it
         // Create new template object
         $tpl = new Template(dirname($admin->correct_theme_source('pages_sections.htt')));
-        // $template->debug = true;
         $tpl->set_file('page', 'pages_sections.htt');
-        $tpl->set_block('page', 'main_block', 'main');
-        $tpl->set_block('main_block', 'module_block', 'module_list');
-        $tpl->set_block('main_block', 'section_block', 'section_list');
-        $tpl->set_block('section_block', 'block_block', 'block_list');
-        $tpl->set_block('main_block', 'calendar_block', 'calendar_list');
-        $tpl->set_var('FTAN', $admin->getFTAN());
+        
+        $tpl->set_block('page',          'main_block',     'main');
+        $tpl->set_block('main_block',    'module_block',   'module_list');
+        $tpl->set_block('main_block',    'section_block',  'section_list');
+        $tpl->set_block('section_block', 'block_block',    'block_list');
+        $tpl->set_block('main_block',    'calendar_block', 'calendar_list');
 
         // set first defaults and messages
-        $tpl->set_var(array(
-            'PAGE_ID' => $results_array['page_id'],
-            // 'PAGE_IDKEY' => $admin->getIDKEY($results_array['page_id']),
-            'PAGE_IDKEY' => $results_array['page_id'],
-            'TEXT_PAGE' => $TEXT['PAGE'],
-            'PAGE_TITLE' => ($results_array['page_title']),
-            'MENU_TITLE' => ($results_array['menu_title']),
-            'TEXT_CURRENT_PAGE' => $TEXT['CURRENT_PAGE'],
-            'HEADING_MANAGE_SECTIONS' => $HEADING['MANAGE_SECTIONS'],
-            'HEADING_MODIFY_PAGE' => $HEADING['MODIFY_PAGE'],
-            'TEXT_CHANGE_SETTINGS' => $TEXT['CHANGE_SETTINGS'],
-            'TEXT_ADD_SECTION' => $TEXT['ADD_SECTION'],
-            'TEXT_ID' => 'ID',
-            'TEXT_TYPE' => $TEXT['TYPE'],
-            'TEXT_BLOCK' => $TEXT['BLOCK'],
-            'TEXT_NAMESECTION' => $TEXT['SECTION'] . ' ' . $TEXT['NAME'],
-            'TEXT_PUBL_START_DATE' => $TEXT{'PUBL_START_DATE'},
-            'TEXT_PUBL_END_DATE' => $TEXT['PUBL_END_DATE'],
-            'TEXT_ACTIONS' => $TEXT['ACTIONS'],
-            'TEXT_BACK' => $TEXT['BACK'],
-            'MODIFIED_BY' => $user['display_name'],
-            'MODIFIED_BY_USERNAME' => $user['username'],
-            'MODIFIED_WHEN' => $modified_ts,
-            'LAST_MODIFIED' => $MESSAGE['PAGES_LAST_MODIFIED'],
-            'ADMIN_URL' => ADMIN_URL,
-            'WB_URL' => WB_URL,
-            'THEME_URL' => THEME_URL,
-        )
+        $tpl->set_var(
+            array(
+                'FTAN' => $admin->getFTAN(),
+                'PAGE_ID' => $aPage['page_id'],
+                'PAGE_IDKEY' => $aPage['page_id'],
+                'TEXT_PAGE' => $TEXT['PAGE'],
+                'PAGE_TITLE' => ($aPage['page_title']),
+                'MENU_TITLE' => ($aPage['menu_title']),
+                'TEXT_CURRENT_PAGE' => $TEXT['CURRENT_PAGE'],
+                'HEADING_MANAGE_SECTIONS' => $HEADING['MANAGE_SECTIONS'],
+                'HEADING_MODIFY_PAGE' => $HEADING['MODIFY_PAGE'],
+                'TEXT_CHANGE_SETTINGS' => $TEXT['CHANGE_SETTINGS'],
+                'TEXT_ADD_SECTION' => $TEXT['ADD_SECTION'],
+                'TEXT_ID' => 'ID',
+                'TEXT_TYPE' => $TEXT['TYPE'],
+                'TEXT_BLOCK' => $TEXT['BLOCK'],
+                'TEXT_NAMESECTION' => $TEXT['SECTION'] . ' ' . $TEXT['NAME'],
+                'TEXT_PUBL_START_DATE' => $TEXT{'PUBL_START_DATE'},
+                'TEXT_PUBL_END_DATE' => $TEXT['PUBL_END_DATE'],
+                'TEXT_ACTIONS' => $TEXT['ACTIONS'],
+                'TEXT_BACK' => $TEXT['BACK'],
+                'MODIFIED_BY' => $user['display_name'],
+                'MODIFIED_BY_USERNAME' => $user['username'],
+                'MODIFIED_WHEN' => $modified_ts,
+                'LAST_MODIFIED' => $MESSAGE['PAGES_LAST_MODIFIED'],
+                'ADMIN_URL' => ADMIN_URL,
+                'WB_URL' => WB_URL,
+                'THEME_URL' => THEME_URL,
+                'VAR_PAGE_TITLE' => $aPage['page_title'],
+                'SETTINGS_LINK' => ADMIN_URL . '/pages/settings.php?page_id=' . $aPage['page_id'],
+                'MODIFY_LINK' => ADMIN_URL . '/pages/modify.php?page_id=' . $aPage['page_id'],
+            )
         );
 
-        // Insert variables
-        $tpl->set_var(array(
-            'PAGE_ID' => $results_array['page_id'],
-            // 'PAGE_IDKEY' => $admin->getIDKEY($results_array['page_id']),
-            'PAGE_IDKEY' => $results_array['page_id'],
-            'VAR_PAGE_TITLE' => $results_array['page_title'],
-            'SETTINGS_LINK' => ADMIN_URL . '/pages/settings.php?page_id=' . $results_array['page_id'],
-            'MODIFY_LINK' => ADMIN_URL . '/pages/modify.php?page_id=' . $results_array['page_id'],
-        )
-        );
+        $sSql = 'SELECT * FROM `{TP}sections` WHERE `page_id` = '.$page_id.' ORDER BY `position` ASC';
+        $rSections = $database->query($sSql);
 
-        $sql = 'SELECT * ';
-        $sql .= 'FROM `' . TABLE_PREFIX . 'sections` ';
-        $sql .= 'WHERE `page_id` = ' . $page_id . ' ';
-        $sql .= 'ORDER BY `position` ASC';
-        $query_sections = $database->query($sql);
-
-        if ($query_sections->numRows() > 0) {
-            $num_sections = $query_sections->numRows();
-            while ($section = $query_sections->fetchRow()) {
+        $num_sections = $rSections->numRows();
+        if ($num_sections > 0) {
+            while ($section = $rSections->fetchRow()) {
                 if (!is_numeric(array_search($section['module'], $module_permissions))) {
                     // Get the modules real name
-                    $sql = 'SELECT `name` FROM `' . TABLE_PREFIX . 'addons` ';
-                    $sql .= 'WHERE `directory` = "' . $section['module'] . '"';
-                    if (!$database->get_one($sql) || !file_exists(WB_PATH . '/modules/' . $section['module'])) {
+                    $sSql = 'SELECT `name` FROM `{TP}addons` WHERE `directory` = "'.$section['module'].'"';
+                    if (!$database->get_one($sSql) || !file_exists(WB_PATH . '/modules/' . $section['module'])) {
                         $edit_page = '<span class="module_disabled">' . $section['module'] . '</span>';
                     } else {
                         $edit_page = '';
                     }
                     $sec_anchor = (defined('SEC_ANCHOR') && (SEC_ANCHOR != '') ? SEC_ANCHOR : '');
-                    $edit_page_0 = '<a id="sid' . $section['section_id'] . '" href="' . ADMIN_URL . '/pages/modify.php?page_id=' . $results_array['page_id'];
+                    $edit_page_0 = '<a id="sid' . $section['section_id'] . '" href="' . ADMIN_URL . '/pages/modify.php?page_id=' . $aPage['page_id'];
                     $edit_page_1 = ($sec_anchor != '') ? '#' . $sec_anchor . $section['section_id'] . '">' : '">';
                     $edit_page_1 .= $section['module'] . '</a>';
                     if (SECTION_BLOCKS) {
@@ -271,18 +259,18 @@ switch ($action) {
                             }
                         }
                         $input_attribute = 'input_normal';
-                        $tpl->set_var(array(
-                            'STYLE_DISPLAY_SECTION_BLOCK' => ' style="visibility:visible;"',
-                            'NAME_SIZE' => 300,
-                            'INPUT_ATTRIBUTE' => $input_attribute,
-                            'VAR_SECTION_ID' => $section['section_id'],
-                            'VAR_SECTION_IDKEY' => $admin->getIDKEY($section['section_id']),
-                            // 'VAR_SECTION_IDKEY' => $section['section_id'],
-                            'VAR_POSITION' => $section['position'],
-                            'LINK_MODIFY_URL_VAR_MODUL_NAME' => $edit_page,
-                            'SELECT' => '',
-                            'SET_NONE_DISPLAY_OPTION' => '',
-                        )
+                        $tpl->set_var(
+                            array(
+                                'STYLE_DISPLAY_SECTION_BLOCK' => ' style="visibility:visible;"',
+                                'NAME_SIZE' => 300,
+                                'INPUT_ATTRIBUTE' => $input_attribute,
+                                'VAR_SECTION_ID' => $section['section_id'],
+                                'VAR_SECTION_IDKEY' => $admin->getIDKEY($section['section_id']),
+                                'VAR_POSITION' => $section['position'],
+                                'LINK_MODIFY_URL_VAR_MODUL_NAME' => $edit_page,
+                                'SELECT' => '',
+                                'SET_NONE_DISPLAY_OPTION' => '',
+                            )
                         );
                         // Add block options to the section_list
                         $tpl->clear_var('block_list');
@@ -302,19 +290,19 @@ switch ($action) {
                             $edit_page = $edit_page_0 . '#wb_' . $edit_page_1;
                         }
                         $input_attribute = 'input_normal';
-                        $tpl->set_var(array(
-                            'STYLE_DISPLAY_SECTION_BLOCK' => ' style="visibility:hidden;"',
-                            'NAME_SIZE' => 300,
-                            'INPUT_ATTRIBUTE' => $input_attribute,
-                            'VAR_SECTION_ID' => $section['section_id'],
-                            'VAR_SECTION_IDKEY' => $admin->getIDKEY($section['section_id']),
-                            // 'VAR_SECTION_IDKEY' => $section['section_id'],
-                            'VAR_POSITION' => $section['position'],
-                            'LINK_MODIFY_URL_VAR_MODUL_NAME' => $edit_page,
-                            'NAME' => htmlentities(strip_tags($block[1])),
-                            'VALUE' => 1,
-                            'SET_NONE_DISPLAY_OPTION' => '',
-                        )
+                        $tpl->set_var(
+                            array(
+                                'STYLE_DISPLAY_SECTION_BLOCK' => ' style="visibility:hidden;"',
+                                'NAME_SIZE' => 300,
+                                'INPUT_ATTRIBUTE' => $input_attribute,
+                                'VAR_SECTION_ID' => $section['section_id'],
+                                'VAR_SECTION_IDKEY' => $admin->getIDKEY($section['section_id']),
+                                'VAR_POSITION' => $section['position'],
+                                'LINK_MODIFY_URL_VAR_MODUL_NAME' => $edit_page,
+                                'NAME' => htmlentities(strip_tags($block[1])),
+                                'VALUE' => 1,
+                                'SET_NONE_DISPLAY_OPTION' => '',
+                            )
                         );
                     }
                     // named sections patch
@@ -343,49 +331,45 @@ switch ($action) {
                         $tpl->set_var(
                             'VAR_MOVE_UP_URL',
                             '<a href="' . ADMIN_URL . '/pages/move_up.php?page_id=' . $page_id . '&amp;section_id=' . $section['section_id'] . '">
-					                                    <img src="' . THEME_URL . '/images/up_16.png" alt="{TEXT_MOVE_UP}" />
-					                                    </a>');
-                    } else {
-                        $tpl->set_var(array(
-                            'VAR_MOVE_UP_URL' => '',
-                        )
+                            <img src="' . THEME_URL . '/images/up_16.png" alt="{TEXT_MOVE_UP}" />
+                            </a>'
                         );
+                    } else {
+                        $tpl->set_var('VAR_MOVE_UP_URL', '');
                     }
                     if ($section['position'] != $num_sections) {
                         $tpl->set_var(
                             'VAR_MOVE_DOWN_URL',
                             '<a href="' . ADMIN_URL . '/pages/move_down.php?page_id=' . $page_id . '&amp;section_id=' . $section['section_id'] . '">
-					                                    <img src="' . THEME_URL . '/images/down_16.png" alt="{TEXT_MOVE_DOWN}" />
-					                                    </a>');
-                    } else {
-                        $tpl->set_var(array(
-                            'VAR_MOVE_DOWN_URL' => '',
-                        )
+                            <img src="' . THEME_URL . '/images/down_16.png" alt="{TEXT_MOVE_DOWN}" />
+                            </a>'
                         );
+                    } else {
+                        $tpl->set_var('VAR_MOVE_DOWN_URL', '');
                     }
                 } else {
                     continue;
                 }
 
                 $tpl->set_var(array(
-                    'DISPLAY_DEBUG' => ' style="visibility="visible;"',
-                    'TEXT_SID' => 'SID',
+                    'DISPLAY_DEBUG'      => ' style="visibility="visible;"',
+                    'TEXT_SID'           => 'SID',
                     'DEBUG_COLSPAN_SIZE' => 9,
                 )
                 );
                 if ($debug) {
                     $tpl->set_var(array(
                         'DISPLAY_DEBUG' => ' style="visibility="visible;"',
-                        'TEXT_PID' => 'PID',
-                        'TEXT_SID' => 'SID',
-                        'POSITION' => $section['position'],
+                        'TEXT_PID'      => 'PID',
+                        'TEXT_SID'      => 'SID',
+                        'POSITION'      => $section['position'],
                     )
                     );
                 } else {
                     $tpl->set_var(array(
                         'DISPLAY_DEBUG' => ' style="display:none;"',
-                        'TEXT_PID' => '',
-                        'POSITION' => '',
+                        'TEXT_PID'      => '',
+                        'POSITION'      => '',
                     )
                     );
                 }
@@ -393,68 +377,55 @@ switch ($action) {
             }
         }
 
-        // now add the calendars -- remember to to set the range to [1970, 2037] if the date is used as timestamp!
-        // the loop is simply a copy from above.
-        $sql = 'SELECT `section_id`,`module` FROM `' . TABLE_PREFIX . 'sections` ';
-        $sql .= 'WHERE page_id = ' . $page_id . ' ';
-        $sql .= 'ORDER BY `position` ASC';
-        $query_sections = $database->query($sql);
+        // Now add the calendars -- remember to set the range to [1970, 2037] if the date is used as timestamp!
+        // The loop is simply a copy from above.
+        $sSql = 'SELECT `section_id`,`module` FROM `{TP}sections` WHERE page_id = ' . $page_id . ' ';
+        $sSql .= 'ORDER BY `position` ASC';
+        $rSections = $database->query($sSql);
 
-        if ($query_sections->numRows() > 0) {
-            $num_sections = $query_sections->numRows();
-            while ($section = $query_sections->fetchRow()) {
+        $num_sections = $rSections->numRows();
+        if ($num_sections > 0) {
+            while ($section = $rSections->fetchRow()) {
                 // Get the modules real name
-                $sql = 'SELECT `name` FROM `' . TABLE_PREFIX . 'addons` ';
-                $sql .= 'WHERE `directory` = "' . $section['module'] . '"';
-                $module_name = $database->get_one($sql);
+                $sSql = 'SELECT `name` FROM `{TP}addons` WHERE `directory` = "'.$section['module'].'"';
+                $module_name = $database->get_one($sSql);
 
                 if (!is_numeric(array_search($section['module'], $module_permissions))) {
                     $tpl->set_var(array(
                         'jscal_ifformat' => $jscal_ifformat,
                         'jscal_firstday' => $jscal_firstday,
-                        'jscal_today' => $jscal_today,
-                        'start_date' => 'start_date' . $section['section_id'],
-                        'end_date' => 'end_date' . $section['section_id'],
-                        'trigger_start' => 'trigger_start' . $section['section_id'],
-                        'trigger_end' => 'trigger_stop' . $section['section_id'],
-                    )
+                        'jscal_today'    => $jscal_today,
+                        'start_date'     => 'start_date' . $section['section_id'],
+                        'end_date'       => 'end_date' . $section['section_id'],
+                        'trigger_start'  => 'trigger_start' . $section['section_id'],
+                        'trigger_end'    => 'trigger_stop' . $section['section_id'],
+                        'showsTime'      => (isset($jscal_use_time) && $jscal_use_time == true) ? "true" : "false",
+                        'timeFormat'     => "24",
+                        )
                     );
-                    if (isset($jscal_use_time) && $jscal_use_time == true) {
-                        $tpl->set_var(array(
-                            'showsTime' => "true",
-                            'timeFormat' => "24",
-                        )
-                        );
-                    } else {
-                        $tpl->set_var(array(
-                            'showsTime' => "false",
-                            'timeFormat' => "24",
-                        )
-                        );
-                    }
                 }
                 $tpl->parse('calendar_list', 'calendar_block', true);
             }
         }
 
         // Work-out if we should show the "Add Section" form
-        $sql = 'SELECT `section_id` FROM `' . TABLE_PREFIX . 'sections` ';
-        $sql .= 'WHERE `page_id` = ' . $page_id . ' AND `module` = "menu_link"';
-        $query_sections = $database->query($sql);
-        if ($query_sections->numRows() == 0) {
+      
+        $sSql = 'SELECT `section_id` FROM `{TP}sections` ';
+        $sSql .= 'WHERE `page_id` = ' . $page_id . ' AND `module` = "menu_link"';
+        $rSections = $database->query($sSql);
+        if ($rSections->numRows() == 0) {
             // Modules list
-            $sql = 'SELECT `name`,`directory`,`type` FROM `' . TABLE_PREFIX . 'addons` ';
-            $sql .= 'WHERE `type` = "module" AND `function` = "page" AND `directory` != "menu_link" ';
-            $sql .= 'ORDER BY `name`';
-            $result = $database->query($sql);
-            // if(DEBUG && $database->is_error()) { $admin->print_error($database->get_error()); }
-
-            if ($result->numRows() > 0) {
-                while ($module = $result->fetchRow()) {
+            $sSql = 'SELECT `name`,`directory`,`type` FROM `{TP}addons` ';
+            $sSql .= 'WHERE `type` = "module" AND `function` = "page" AND `directory` != "menu_link" ';
+            $sSql .= 'ORDER BY `name`';
+            $rResult = $database->query($sSql);
+            
+            if ($rResult->numRows() > 0) {
+                while ($module = $rResult->fetchRow()) {
                     // Check if user is allowed to use this module   echo  $module['directory'],'<br />';
                     if (!is_numeric(array_search($module['directory'], $module_permissions))) {
                         $tpl->set_var('VALUE', $module['directory']);
-                        $tpl->set_var('NAME', $module['name']);
+                        $tpl->set_var('NAME', $admin->get_module_name($module['name']));
                         if ($module['directory'] == 'wysiwyg') {
                             $tpl->set_var('SELECTED', ' selected="selected"');
                         } else {
@@ -468,22 +439,23 @@ switch ($action) {
             }
         }
         // Insert language text and messages
-        $tpl->set_var(array(
-            'TEXT_MANAGE_SECTIONS' => $HEADING['MANAGE_SECTIONS'],
-            'TEXT_ARE_YOU_SURE' => $TEXT['ARE_YOU_SURE'],
-            'TEXT_TYPE' => $TEXT['TYPE'],
-            'TEXT_ADD' => $TEXT['ADD'],
-            'TEXT_SAVE' => $TEXT['SAVE'],
-            'TEXTLINK_MODIFY_PAGE' => $HEADING['MODIFY_PAGE'],
-            'TEXT_CALENDAR' => $TEXT['CALENDAR'],
-            'TEXT_DELETE_DATE' => $TEXT['DELETE_DATE'],
-            'TEXT_ADD_SECTION' => $TEXT['ADD_SECTION'],
-            'TEXT_MOVE_UP' => $TEXT['MOVE_UP'],
-            'TEXT_MOVE_DOWN' => $TEXT['MOVE_DOWN'],
-            'MODIFIED_BY' => $user['display_name'],
-            'MODIFIED_BY_USERNAME' => $user['username'],
-            'MODIFIED_WHEN' => $modified_ts,
-        )
+        $tpl->set_var(
+            array(
+                'TEXT_MANAGE_SECTIONS' => $HEADING['MANAGE_SECTIONS'],
+                'TEXT_ARE_YOU_SURE' => $TEXT['ARE_YOU_SURE'],
+                'TEXT_TYPE' => $TEXT['TYPE'],
+                'TEXT_ADD' => $TEXT['ADD'],
+                'TEXT_SAVE' => $TEXT['SAVE'],
+                'TEXTLINK_MODIFY_PAGE' => $HEADING['MODIFY_PAGE'],
+                'TEXT_CALENDAR' => $TEXT['CALENDAR'],
+                'TEXT_DELETE_DATE' => $TEXT['DELETE_DATE'],
+                'TEXT_ADD_SECTION' => $TEXT['ADD_SECTION'],
+                'TEXT_MOVE_UP' => $TEXT['MOVE_UP'],
+                'TEXT_MOVE_DOWN' => $TEXT['MOVE_DOWN'],
+                'MODIFIED_BY' => $user['display_name'],
+                'MODIFIED_BY_USERNAME' => $user['username'],
+                'MODIFIED_WHEN' => $modified_ts,
+            )
         );
         $tpl->parse('main', 'main_block', false);
         $tpl->pparse('output', 'page');

--- a/wbce/modules/captcha_control/languages/DE.php
+++ b/wbce/modules/captcha_control/languages/DE.php
@@ -27,11 +27,12 @@
 */
 
 // Deutsche Modulbeschreibung
-$module_description 	= 'Admin-Tool um das Verhalten von CAPTCHA und ASP zu kontrollieren';
+$module_name        = 'CAPTCHA und Advanced Spam Protection (Fortgeschrittener Spam-Schutz)';
+$module_description = 'Admin-Tool um das Verhalten von CAPTCHA und ASP zu konfigurieren.';
 
 // Ueberschriften und Textausgaben
 $MOD_CAPTCHA_CONTROL['HEADING']           = 'Captcha- und ASP Steuerung';
-$MOD_CAPTCHA_CONTROL['HOWTO']             = 'Hiermit kann das Verhalten von "CAPTCHA" und "Advanced Spam Protection" (ASP) gesteuert werden. Damit ASP in einem Modul wirken kann, muss das verwendete Modul entsprechend angepasst sein.';
+$MOD_CAPTCHA_CONTROL['HOWTO']             = 'Hiermit kann das Verhalten von "CAPTCHA" und "Advanced Spam Protection" (ASP) konfiguriert werden. Damit ASP in einem Modul wirken kann, muss das verwendete Modul entsprechend angepasst sein.';
 
 // Text and captions of form elements
 $MOD_CAPTCHA_CONTROL['CAPTCHA_CONF']      = 'CAPTCHA-Einstellungen';

--- a/wbce/modules/menu_link/languages/DE.php
+++ b/wbce/modules/menu_link/languages/DE.php
@@ -11,6 +11,7 @@
  */
 
 // Deutsche Modulbeschreibung
+$module_name = 'Men&uuml;-Link'; 
 $module_description = 'Dieses Modul erm&ouml;glicht die Anzeige eines Links im Seitenmen&uuml;.';
 
 // Ueberschriften und Textausgaben

--- a/wbce/modules/mod_opf_email/filter.php
+++ b/wbce/modules/mod_opf_email/filter.php
@@ -35,8 +35,6 @@ if(!defined('WB_PATH')) {
  * @param string $content
  * @return string
  */
-
-
 function doFilterEmail($content) {
 
     // check if required arguments are defined otherwise define
@@ -48,14 +46,16 @@ function doFilterEmail($content) {
     // If necessary (Both true) check if mdcr.js is added to the head of template
     // In not try to add it.
     if (Settings::Get('OPF_MAILTO_FILTER') and Settings::Get('OPF_JS_MAILTO')){
-    // test if js-decryption is installed(was needed as frontend functions where adding this too possibly we can remove this test)
+        // test if js-decryption is installed(was needed as frontend functions 
+        // where adding this too possibly we can remove this test)
         if( !preg_match('/<head.*<.*src=\".*\/mdcr.js.*>.*<\/head/siU', $content) ) {
             // try to insert js-decrypt into <head> if available
-            $script = str_replace('\\', '/',str_replace(WB_PATH,'', dirname(dirname(__FILE__))).'/js/mdcr.js');
-            if(is_readable(WB_PATH.$script)) {
-                $scriptLink = "\t".'<script src="'.WB_URL.$script.'" type="text/javascript"></script>'."\n\n";
+            $sJsFilePath = __DIR__ .'/js/mdcr.js';
+            if(file_exists($sJsFilePath)){
+                $sJsFileUrl = get_url_from_path($sJsFilePath); 
+                $sScriptTag = "\t".'<script src="'. $sJsFileUrl .'" type="text/javascript"></script>'."\n\n";
                 $regex = '/(.*)(<\s*?\/\s*?head\s*>.*)/isU';
-                $replace = '$1'.$scriptLink.'$2';
+                $replace = '$1'. $sScriptTag .'$2';
                 $content = preg_replace ($regex, $replace, $content);
             }
         }
@@ -130,6 +130,8 @@ function _cbDoExecuteFilter($match) {
                 $class_attr = empty($class_attr) ? '' : 'class="' . $class_attr[2] . '" ';
                 preg_match('/id\s*?=\s*?("|\')(.*?)\1/ix', $match[0], $id_attr);
                 $id_attr = empty($id_attr) ? '' : 'id="' . $id_attr[2] . '" ';
+                preg_match('/style\s*?=\s*?("|\')(.*?)\1/ix', $match[0], $style_attr);
+                $style_attr = empty($style_attr) ? '' : 'style="' . $style_attr[2] . '" ';
             // preprocess mailto link parts for further usage
                 $search = array('@', '.', '_', '-'); $replace = array('F', 'Z', 'X', 'K');
                 $email_address = str_replace($search, $replace, strtolower($match[2]));
@@ -148,7 +150,7 @@ function _cbDoExecuteFilter($match) {
                 }
                 $encrypted_email .= chr($shift + 97);
             // build the encrypted Javascript mailto link
-                $mailto_link  = "<a {$class_attr}{$id_attr}href=\"javascript:mdcr('$encrypted_email','$email_subject')\">" .$match[5] ."</a>";
+                $mailto_link  = "<a {$class_attr}{$id_attr}{$style_attr}href=\"javascript:mdcr('$encrypted_email','$email_subject')\">" .$match[5] ."</a>";
                 return $mailto_link;
             } else {
             /** DO NOT USE JAVASCRIPT ENCRYPTION FOR MAILTO LINKS **/


### PR DESCRIPTION
This commit introduces a new feature with the possibility to translate the $module_name variable (which is set in the info.php of the module in EN only).
It is now possible to translate the $module_name to every language using the language file of the module.

The translated $module_name string will be output in Admin Tools overview list;
in the Add Page/Add Section dialogue (drop down module selection);
in addons/modules drop down combo boxes and the details view of the module;
in group settings where module permissions can be selected/deselected for each group

This commit adds two modules where there is already a translation of the $module_name into DE (German): The Menu Link module and the Advanced Spam Protection Admin Tool.
