### PR TITLE
ensure that the database tables are created during update process

### DIFF
--- a/wbce/install/install_prepare.sql
+++ b/wbce/install/install_prepare.sql
@@ -1,0 +1,55 @@
+-- phpMyAdmin SQL Dump
+-- version 4.0.4.1
+-- http://www.phpmyadmin.net
+--
+-- Host: 127.0.0.1
+-- Erstellungszeit: 14. Aug 2014 um 10:46
+-- Server Version: 5.5.32
+-- PHP-Version: 5.4.19
+
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+-- --------------------------------------------------------
+-- Database structure for module 'news'
+--
+-- Replacements: {TABLE_PREFIX}, {TABLE_ENGINE}, {TABLE_COLLATION}
+--
+-- --------------------------------------------------------
+--
+-- Tabellenstruktur für Tabelle `addons`
+--
+DROP TABLE IF EXISTS `{TABLE_PREFIX}addons`;
+-- --------------------------------------------------------
+--
+-- Tabellenstruktur für Tabelle `groups`
+--
+DROP TABLE IF EXISTS `{TABLE_PREFIX}groups`;
+-- --------------------------------------------------------
+--
+-- Tabellenstruktur für Tabelle `pages`
+--
+DROP TABLE IF EXISTS `{TABLE_PREFIX}pages`;
+-- --------------------------------------------------------
+--
+-- Tabellenstruktur für Tabelle `search`
+--
+DROP TABLE IF EXISTS `{TABLE_PREFIX}search`;
+-- --------------------------------------------------------
+--
+-- Tabellenstruktur für Tabelle `sections`
+--
+DROP TABLE IF EXISTS `{TABLE_PREFIX}sections`;
+-- --------------------------------------------------------
+--
+-- Tabellenstruktur für Tabelle `settings`
+--
+DROP TABLE IF EXISTS `{TABLE_PREFIX}settings`;
+-- --------------------------------------------------------------------
+--
+-- Tabellenstruktur für Tabelle `users` (new fields since WBCE v.1.4.0)
+--
+DROP TABLE IF EXISTS `{TABLE_PREFIX}users`;
+-- --------------------------------------------------------------------
+--
+-- Tabellenstruktur für Tabelle `blocking` (new table since WBCE v.1.4.0)
+--
+DROP TABLE IF EXISTS `{TABLE_PREFIX}blocking`;

--- a/wbce/install/install_struct.sql
+++ b/wbce/install/install_struct.sql
@@ -17,7 +17,6 @@ SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 --
 -- Tabellenstruktur für Tabelle `addons`
 --
-DROP TABLE IF EXISTS `{TABLE_PREFIX}addons`;
 CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}addons` (
   `addon_id` int(11) NOT NULL AUTO_INCREMENT,
   `type` varchar(255){TABLE_COLLATION} NOT NULL DEFAULT '',
@@ -35,7 +34,6 @@ CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}addons` (
 --
 -- Tabellenstruktur für Tabelle `groups`
 --
-DROP TABLE IF EXISTS `{TABLE_PREFIX}groups`;
 CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}groups` (
   `group_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255){TABLE_COLLATION} NOT NULL DEFAULT '',
@@ -48,7 +46,6 @@ CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}groups` (
 --
 -- Tabellenstruktur für Tabelle `pages`
 --
-DROP TABLE IF EXISTS `{TABLE_PREFIX}pages`;
 CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}pages` (
   `page_id` int(11) NOT NULL AUTO_INCREMENT,
   `parent` int(11) NOT NULL DEFAULT '0',
@@ -79,7 +76,6 @@ CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}pages` (
 --
 -- Tabellenstruktur für Tabelle `search`
 --
-DROP TABLE IF EXISTS `{TABLE_PREFIX}search`;
 CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}search` (
   `search_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255){TABLE_COLLATION} NOT NULL DEFAULT '',
@@ -91,7 +87,6 @@ CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}search` (
 --
 -- Tabellenstruktur für Tabelle `sections`
 --
-DROP TABLE IF EXISTS `{TABLE_PREFIX}sections`;
 CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}sections` (
   `section_id` int(11) NOT NULL AUTO_INCREMENT,
   `page_id` int(11) NOT NULL DEFAULT '0',
@@ -107,7 +102,6 @@ CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}sections` (
 --
 -- Tabellenstruktur für Tabelle `settings`
 --
-DROP TABLE IF EXISTS `{TABLE_PREFIX}settings`;
 CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}settings` (
   `setting_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255){TABLE_COLLATION} NOT NULL DEFAULT '',
@@ -118,7 +112,6 @@ CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}settings` (
 --
 -- Tabellenstruktur für Tabelle `users` (new fields since WBCE v.1.4.0)
 --
-DROP TABLE IF EXISTS `{TABLE_PREFIX}users`;
 CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}users` (
   `user_id` int(11) NOT NULL AUTO_INCREMENT,
   `group_id` int(11) NOT NULL DEFAULT '0',
@@ -151,7 +144,6 @@ CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}users` (
 --
 -- Tabellenstruktur für Tabelle `blocking` (new table since WBCE v.1.4.0)
 --
-DROP TABLE IF EXISTS `{TABLE_PREFIX}blocking`;
 CREATE TABLE IF NOT EXISTS `{TABLE_PREFIX}blocking` (
   `source_ip` varchar(50){TABLE_COLLATION} NOT NULL DEFAULT '',
   `timestamp` int(11) NOT NULL DEFAULT '0',

--- a/wbce/install/save.php
+++ b/wbce/install/save.php
@@ -345,12 +345,13 @@ if (!defined('WB_INSTALL_PROCESS')) {
 Begin Create Database Tables
  *****************************/
 $aSqlFiles = array(
+    'install_prepare.sql',
     'install_struct.sql',
     'install_data.sql'
 );
 foreach ($aSqlFiles as $sFileName){
     $sFile = dirname(__FILE__).'/'.$sFileName;
-    $bPreserve = ($sFileName == "install_struct.sql") ? false : true;
+    $bPreserve = ($sFileName == "install_prepare.sql") ? false : true;
     if (is_readable($sFile)) {
         if (!$database->SqlImport($sFile, TABLE_PREFIX, $bPreserve)) {
             set_error(d('e23: ')."Unable to read import 'install/".$sFileName."'".d($database->get_error(),"",true));

--- a/wbce/install/update.php
+++ b/wbce/install/update.php
@@ -152,7 +152,7 @@ require_once WB_PATH . '/framework/functions.php';
 require_once WB_PATH . '/framework/class.admin.php';
 $admin = new admin('Addons', 'modules', false, false);
 
-// database tables including in package
+// database tables included in package
 $table_list = array('settings', 'groups', 'addons', 'pages', 'sections', 'search', 'users', 'mod_droplets', 'mod_outputfilter_dashboard', 'mod_miniform','mod_wbstats_day', 'mod_menu_link', 'blocking');
 /*
 $table_list = array (
@@ -352,6 +352,27 @@ exit();
                 <td><?php
 
 
+
+/*********************************************************************
+* First of all Create Database Tables required for the current version
+*/
+
+echo "Ensure the needed database tables are there<br />";
+$sFileName = 'install_struct.sql';
+$sFile = dirname(__FILE__).'/'.$sFileName;
+if (is_readable($sFile)) {
+    if (!$database->SqlImport($sFile, TABLE_PREFIX)) {
+	echo (__LINE__ .": Unable to read import 'install/".$sFileName."'".$database->get_error().'<br />');
+    }
+} else {
+    if(file_exists($sFile)){
+        echo (__LINE__ .": Unable to read file 'install/".$sFileName."'<br />");
+    }else{
+        echo (__LINE__ .": File 'install/".$sFileName."' doesn't exist!<br />");
+    }
+}
+
+
 /**********************************************************
 * Adding field default_theme to settings table
 */
@@ -443,20 +464,13 @@ if (file_exists($file_name)) {
 // Remove entry from DB
 $database->query("DELETE FROM ".TABLE_PREFIX."addons WHERE directory = 'output_filter' AND type = 'module'");
 
-// Create new core table(s)
-$database->query("CREATE TABLE IF NOT EXISTS `".TABLE_PREFIX."blocking` ("
-  . " `source_ip` varchar(50) collate utf8_unicode_ci NOT NULL DEFAULT '',"
-  . " `timestamp` int(11) NOT NULL DEFAULT '0',"
-  . " `attempts` int(11) NOT NULL DEFAULT '0',"
-  . " PRIMARY KEY (`source_ip`)"
-  . ")");
-echo ($database->is_error() ? __LINE__ .': '.$database->get_error().'<br />' : '');
+
 
 // check again all tables, to get a new array
 if (sizeof($all_tables) < sizeof($table_list)) {$all_tables = check_wb_tables();}
 
 /**********************************************************
-* check tables comin with WBCE
+* check tables coming with WBCE
 */
 
 $check_text = 'total ';


### PR DESCRIPTION
under some conditions it may have happened that not all tables were created correctly, so we explicitly call the statements directly from the update script.
Note that we still keep the mechanism in dbsession: it also alters tables if the encoding is not the preferred one.
We also keep the checks on the required tables in the update script in case anything went wrong with creating the tables.
The 'drop table' statements are moved into a separate file, just as a precautious measure not to lose data in case someone changes the call to the sql import in the future and makes a silly mistake. Not to have the drops in the same file is really an easy change and it can prevent us and our users from so much trouble.