### PR TITLE
feat(wbce_flat_theme): Responsive mobile support

### DIFF
--- a/wbce/templates/wbce_flat_theme/css/login.css
+++ b/wbce/templates/wbce_flat_theme/css/login.css
@@ -128,6 +128,6 @@ a:hover {
     }
 
     .page_login_slogan {
-        top: 150px;
+        top: 0;
     }
 }

--- a/wbce/templates/wbce_flat_theme/css/theme.css
+++ b/wbce/templates/wbce_flat_theme/css/theme.css
@@ -1485,9 +1485,15 @@ form.advanced-options {
 /* --- Smartphones (≤ 480px) --- */
 @media screen and (max-width: 480px) {
 
-    /* Sidebar fully hidden, content uses full width */
-    #sidebararea {
+    /* Sidebar fully hidden when collapsed */
+    #sidebararea.closedsidebar {
         left: -350px;
+    }
+
+    /* Sidebar slides in as overlay when opened */
+    #sidebararea:not(.closedsidebar) {
+        left: 0;
+        box-shadow: 6px 0 20px rgba(0, 0, 0, 0.4);
     }
 
     #mainarea {

--- a/wbce/templates/wbce_flat_theme/css/theme.css
+++ b/wbce/templates/wbce_flat_theme/css/theme.css
@@ -1485,23 +1485,78 @@ form.advanced-options {
 /* --- Smartphones (≤ 480px) --- */
 @media screen and (max-width: 480px) {
 
-    /* Sidebar fully hidden when collapsed */
-    #sidebararea.closedsidebar {
-        left: -350px;
+    /* Sidebar 15% kleiner auf Mobilgeräten */
+    #sidebararea {
+        width: 298px;
+        padding: 102px 14px 14px;
+        font-size: 85%;
     }
 
-    /* Sidebar slides in as overlay when opened */
+    #sidebararea #userbox {
+        padding-top: 10px;
+        padding-bottom: 10px;
+        padding-left: 77px;
+        background-position: 17px 10px;
+        background-size: 38px auto;
+    }
+
+    #sidebararea #user-name {
+        padding-bottom: 10px;
+        font-size: 17px;
+    }
+
+    #sidebararea #user-button {
+        right: 14px;
+        bottom: 10px;
+    }
+
+    #sidebararea #mainmenu {
+        margin-right: -14px;
+        margin-top: 31px;
+        padding-left: 43px;
+        font-size: 14px;
+    }
+
+    #sidebararea #mainmenu ul li a {
+        margin-right: -13px;
+        padding-top: 10px;
+        padding-bottom: 10px;
+        padding-left: 68px;
+    }
+
+    #sidebararea #mainmenu ul li a:before {
+        width: 60px;
+        padding-top: 10px;
+        font-size: 22px;
+    }
+
+    #sidebararea #systeminfo {
+        margin-top: 31px;
+    }
+
+    /* Sidebar fully hidden when collapsed */
+    #sidebararea.closedsidebar {
+        left: -298px;
+    }
+
+    /* Sidebar slides in as full overlay when opened */
     #sidebararea:not(.closedsidebar) {
         left: 0;
         box-shadow: 6px 0 20px rgba(0, 0, 0, 0.4);
     }
 
-    #mainarea {
+    /* Content uses full width in both states (sidebar overlays when open).
+       High-specificity selectors needed to beat .container #mainarea.closedsidebar */
+    #mainarea,
+    .container #mainarea,
+    .container #mainarea.closedsidebar {
         padding-left: 2%;
         padding-right: 2%;
     }
 
-    #pagetopmenu {
+    /* Top menu: no left padding in either state */
+    #pagetopmenu,
+    #pagetopmenu.closedsidebar {
         padding-left: 0;
     }
 

--- a/wbce/templates/wbce_flat_theme/css/theme.css
+++ b/wbce/templates/wbce_flat_theme/css/theme.css
@@ -1400,8 +1400,146 @@ form.advanced-options {
 
 
 .pagetree-no-edit {
-	color:#666; 
-	font-weight:400; 
-	cursor:not-allowed;
-	text-decoration:none !important;
-} 
+    color: #666;
+    font-weight: 400;
+    cursor: not-allowed;
+    text-decoration: none !important;
+}
+
+/* ============================================================
+   RESPONSIVE / MOBILE
+   ============================================================ */
+
+/* Smooth transitions for sidebar open/close */
+#sidebararea,
+#mainarea,
+#pagetopmenu {
+    transition: left 0.25s ease, padding-left 0.25s ease;
+}
+
+/* Mobile backdrop overlay (hidden by default) */
+#sidebar-backdrop {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1999;
+    cursor: pointer;
+}
+
+#sidebar-backdrop.active {
+    display: block;
+}
+
+/* --- Small desktops / large tablets (≤ 900px) --- */
+@media screen and (max-width: 900px) {
+    .wdt500, .wdt550, .wdt600 {
+        width: 100% !important;
+        max-width: 100% !important;
+    }
+}
+
+/* --- Tablets (≤ 768px) --- */
+@media screen and (max-width: 768px) {
+
+    /* Content uses icon-strip width (sidebar starts collapsed) */
+    #mainarea {
+        padding-left: 72px;
+    }
+
+    #pagetopmenu {
+        padding-left: 72px;
+    }
+
+    /* Sidebar overlays content when opened on mobile */
+    #sidebararea:not(.closedsidebar) {
+        box-shadow: 6px 0 20px rgba(0, 0, 0, 0.4);
+    }
+
+    /* Responsive utility width classes */
+    .wdt300, .wdt350, .wdt400 {
+        width: 100% !important;
+        max-width: 100% !important;
+    }
+
+    /* Tables: enable horizontal scroll */
+    .content-box {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    div.pages_list {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    #page-sections {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+/* --- Smartphones (≤ 480px) --- */
+@media screen and (max-width: 480px) {
+
+    /* Sidebar fully hidden, content uses full width */
+    #sidebararea {
+        left: -350px;
+    }
+
+    #mainarea {
+        padding-left: 2%;
+        padding-right: 2%;
+    }
+
+    #pagetopmenu {
+        padding-left: 0;
+    }
+
+    /* Compact top menu buttons */
+    #pagetopmenu ul li a,
+    #pagetopmenu a#sidebararea_togglebutton {
+        width: 46px;
+        padding: 6px 10px;
+        font-size: 22px;
+    }
+
+    /* Medium utility classes also fluid */
+    .wdt150, .wdt200, .wdt250 {
+        width: 100% !important;
+        max-width: 100% !important;
+    }
+
+    /* Inputs don't overflow viewport */
+    input[type="text"],
+    input[type="password"],
+    input[type="email"],
+    input[type="number"],
+    textarea {
+        max-width: 100%;
+    }
+
+    /* Compact themeboxes */
+    .themebox .tb_header {
+        width: 70px;
+    }
+
+    .themebox .tb_content {
+        margin-left: 70px;
+        padding: 12px 12px 24px 8px;
+    }
+
+    .themebox .tb_header a::before,
+    .themebox .tb_header span.tb_icon {
+        font-size: 40px;
+        line-height: 44px;
+    }
+
+    /* Contentarea: less padding */
+    #contentarea {
+        padding-bottom: 16px;
+    }
+}

--- a/wbce/templates/wbce_flat_theme/info.php
+++ b/wbce/templates/wbce_flat_theme/info.php
@@ -14,9 +14,9 @@
 $template_directory = 'wbce_flat_theme';
 $template_name = 'WBCE Flat Theme';
 $template_function = 'theme';
-$template_version = '1.7.11';
+$template_version = '1.8.1';
 $template_platform = '1.5.0';
 $template_author = 'Colinax based on the work by Yetiie, BerndJM and rjgamer';
 $template_license = 'GNU General Public License';
 $template_license_terms = '-';
-$template_description = 'Flat theme for WBCE 1.x';
+$template_description = 'Ein erweitertes, responsive Backend-Theme für WBCE';

--- a/wbce/templates/wbce_flat_theme/jquery/theme.js
+++ b/wbce/templates/wbce_flat_theme/jquery/theme.js
@@ -60,10 +60,30 @@ $(document).ready(function () {
         pageModus: 'domainWide'
     }); // ENDE make sidebar state sticky
 
+    // Mobile: always start with sidebar collapsed on small screens
+    // (overrides sticky state restored by plugin above)
+    var $sidebarElems = $('#pagetopmenu, #mainarea, #sidebararea, #mainmenu, #mainmenu ul, #userbox, #systeminfo');
+    if ($(window).width() <= 768) {
+        $sidebarElems.addClass('closedsidebar');
+    }
+
+    // Mobile backdrop element
+    $('<div id="sidebar-backdrop"></div>').appendTo('body');
+
+    function closeSidebarMobile() {
+        $sidebarElems.addClass('closedsidebar');
+        $('#sidebar-backdrop').removeClass('active');
+    }
+
+    // Close sidebar when backdrop is clicked
+    $('#sidebar-backdrop').on('click', function () {
+        closeSidebarMobile();
+    });
+
     // toggle-action for sidebar
     $('#sidebararea_togglebutton').click(function () {
         if ($(this).parent().hasClass('closedsidebar')) {
-            // close sidebar
+            // Sidebar is closed → open it
             $('#pagetopmenu').removeClass('closedsidebar', 1000);
             $('#mainarea').removeClass('closedsidebar', 1000);
             $('#sidebararea').removeClass('closedsidebar', 1000);
@@ -72,8 +92,12 @@ $(document).ready(function () {
                 $('#userbox').removeClass('closedsidebar', 800);
                 $('#systeminfo').removeClass('closedsidebar', 800);
             });
+            // Show backdrop on mobile
+            if ($(window).width() <= 768) {
+                $('#sidebar-backdrop').addClass('active');
+            }
         } else {
-            // sidebar is open --> close sidebar
+            // Sidebar is open → close it
             $('#userbox').addClass('closedsidebar', 800);
             $('#systeminfo').addClass('closedsidebar', 800);
             $('#sidebararea').addClass('closedsidebar', 1000);
@@ -81,6 +105,7 @@ $(document).ready(function () {
             $('#mainmenu').addClass('closedsidebar', 1000);
             $('#pagetopmenu').addClass('closedsidebar', 1000);
             $('#mainarea').addClass('closedsidebar', 1000);
+            $('#sidebar-backdrop').removeClass('active');
             sidebararea_close_switch = 0;
         }
     }); // ENDE script toggle action for sidebar

--- a/wbce/templates/wbce_flat_theme/jquery/theme.js
+++ b/wbce/templates/wbce_flat_theme/jquery/theme.js
@@ -80,6 +80,17 @@ $(document).ready(function () {
         closeSidebarMobile();
     });
 
+    // Collapse sidebar automatically when resizing into mobile breakpoint
+    var wasNarrow = $(window).width() <= 768;
+    $(window).on('resize', function () {
+        var isNarrow = $(window).width() <= 768;
+        if (isNarrow && !wasNarrow) {
+            // Crossed into mobile: collapse sidebar and hide backdrop
+            closeSidebarMobile();
+        }
+        wasNarrow = isNarrow;
+    });
+
     // toggle-action for sidebar
     $('#sidebararea_togglebutton').click(function () {
         if ($(this).parent().hasClass('closedsidebar')) {

--- a/wbce/templates/wbce_flat_theme/templates/header.htt
+++ b/wbce/templates/wbce_flat_theme/templates/header.htt
@@ -12,6 +12,7 @@
 
 <!--(PH) META HEAD+ -->
 <meta charset="{CHARSET}">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <meta http-equiv="Content-Encoding" content="gzip" />
 <meta http-equiv="Accept-Encoding" content="gzip, deflate" />
 <!--(PH) META HEAD- -->

--- a/wbce/templates/wbce_flat_theme/templates/header.htt
+++ b/wbce/templates/wbce_flat_theme/templates/header.htt
@@ -87,8 +87,17 @@
         <span class="version">WBCE Version: {WBCE_VERSION}</span><br/>
         <span class="version">Tag: {WBCE_TAG}</span><br/>
         <span class="version">PHP Version: {PHP_VERSION}</span><br/>
-        <span class="version">Session timeout: <span id="countdown" class="timer"></span></span>
+        <span class="version">Session timeout: <span id="countdown" class="timer"></span></span><br/>
+        <span class="version">Viewport: <span id="viewport-size"></span></span>
     </div>
+<script>
+function updateViewportSize() {
+    var el = document.getElementById('viewport-size');
+    if (el) el.textContent = window.innerWidth + ' x ' + window.innerHeight + ' px';
+}
+updateViewportSize();
+window.addEventListener('resize', updateViewportSize);
+</script>
 </div>
 <div id="mainarea" class="stickySidebarElement">
 <div id="contentarea">


### PR DESCRIPTION
 ## Summary

  Improves the `wbce_flat_theme` backend theme for tablet and smartphone use.

  - Add missing viewport meta tag for correct mobile scaling
  - Sidebar collapses automatically on page load when viewport ≤ 768px
  - Sidebar collapses automatically when resizing from desktop into mobile breakpoint
  - Mobile backdrop overlay: tap outside sidebar to close it
  - Smartphones (≤ 480px): sidebar slides in as full-width overlay, content uses full viewport width
  - Smartphones (≤ 480px): sidebar scaled 15% smaller (298px width, reduced paddings/fonts)
  - Compact top-menu buttons on smartphones (46px)
  - Fluid utility width classes at 900 / 768 / 480px breakpoints
  - Live viewport size display in systeminfo panel (debug aid)
  - Version bumped to 1.8.1