### PR TITLE
fix(framework): Fatal Errors bei Login und Session (PHP 8.x)

### DIFF
--- a/wbce/framework/class.login.php
+++ b/wbce/framework/class.login.php
@@ -534,7 +534,7 @@ class Login extends Admin
             require_once WB_PATH . '/include/phplib/template.inc';
             $oTemplate = new Template(dirname($this->correct_theme_source($this->template_file)));
             $oTemplate->set_file('page', $this->template_file);
-            $oTemplate->set_block('page', 'mainBlock', 'main');
+            $oTemplate->set_block('page', 'main_block', 'main');
             if ($this->remember_me_option != true) {
                 $oTemplate->set_var('DISPLAY_REMEMBER_ME', 'display: none;');
             } else {
@@ -573,7 +573,7 @@ class Login extends Admin
 				'CAPTCHA' => $captcha
             ));
 
-            $oTemplate->parse('main', 'mainBlock', false);
+            $oTemplate->parse('main', 'main_block', false);
             $oTemplate->pparse('output', 'page');
         }
     }

--- a/wbce/framework/wsession.php
+++ b/wbce/framework/wsession.php
@@ -106,8 +106,7 @@ class WSession
             // Session identifier used by Secureform class , so we dont need to use session_id
             // and tokens stay valid if we just refresh session id
             if (WSession::Get('SessionTokenIdentifier') == false) {
-                $rnd = new RandomGen();
-                WSession::Set('SessionTokenIdentifier', $rnd->TextToken(32));
+                WSession::Set('SessionTokenIdentifier', bin2hex(random_bytes(16)));
             }
 
             // this is used by only by installer in index.php and save.php we will remove this later


### PR DESCRIPTION
 ## Problem

  Two fatal errors in WBCE 1.7.0 under PHP 8.x make the backend completely unusable.

  ## Changes

  **`wbce/framework/wsession.php`**
  - Replaced `new RandomGen()` with `bin2hex(random_bytes(16))`
  - Class `RandomGen` is not defined anywhere in the repository → `Fatal Error: Class "RandomGen" not found` on every
  page load

  **`wbce/framework/class.login.php`**
  - Fixed template block name `mainBlock` → `main_block` (lines 537 and 576)
  - All `.htt` templates in the project use `snake_case` (`main_block`); the mismatched name caused the login page to
  render blank

  ## Tested

  - PHP 8.x: no fatal error on backend load
  - Login page renders correctly