### PR TITLE
Regular expression not matching

### DIFF
--- a/wbce/framework/class.settings.php
+++ b/wbce/framework/class.settings.php
@@ -90,7 +90,7 @@ class Settings
 
 
         // Make sure we only  got 'a-zA-Z0-9_'
-        if (!preg_match("/[a-zA-Z0-9\-]+/u", $name)) {
+        if (empty($name) || !preg_match('/^[a-zA-Z0-9_]+$/', $name)) {
             return "Name only may contain 'a-zA-Z0-9_'";
         }
         $name = strtolower($name);


### PR DESCRIPTION
The regExp inside "class.settings.php" doesn't match correct - it allows nearly _all_ chars!
As far as i can see it now - this is corrected in the 1.7.0 Project (wbeasy).
Kind regards