### PR TITLE
Missformated info.php

### DIFF
--- a/wbce/modules/logrotate/info.php
+++ b/wbce/modules/logrotate/info.php
@@ -1,1 +1,17 @@
-<?php/**	@version	0.1.0*	@author		Ruud Eisinga - Dev4me.com*	@date		2020-12-09**/$module_directory = 'logrotate';$module_name = 'Automatic rotating the errorlogs based on size';$module_function = 'snippet';$module_version = '0.1.0';$module_platform = '2.10.x';$module_author = 'dev4me.com';$module_license = 'GNU General Public License';$module_description = 'This snippet checks the errorlog and will rotate it on size.';
+<?php
+/*
+*	@version	0.1.0
+*	@author		Ruud Eisinga - Dev4me.com
+*	@date		2020-12-09
+*
+*/
+
+
+$module_directory = 'logrotate';
+$module_name = 'Automatic rotating the errorlogs based on size';
+$module_function = 'snippet';
+$module_version = '0.1.0';
+$module_platform = '2.10.x';
+$module_author = 'dev4me.com';
+$module_license = 'GNU General Public License';
+$module_description = 'This snippet checks the errorlog and will rotate it on size.';


### PR DESCRIPTION
Hm ...
Installation aborted due to incorrectly formatted info.php from "logrotate".

>> Parse error: syntax error, unexpected variable "$module_directory" in ####/cms-scriptorium/www/wbce168/wbce/modules/logrotate/info.php on line 1
