### PR TITLE
Missing var in install/save causes warning during installation

### DIFF
--- a/wbce/install/save.php
+++ b/wbce/install/save.php
@@ -278,7 +278,7 @@ try {
     }
 } catch (Exception $e) {
     $sMsg = d('e29: ') . 'Cannot connect to Database. Check host name, username, DB name and password.<br />Error:<br />'
-        . $e->getMessage() . "Host: database_host, User: $database_username, Pass: $database_password, DB-Name: $database_name, Port: $database_port";
+        . $e->getMessage() . "Host: database_host, User: $database_username, Pass: $database_password, DB-Name: $database_name, Port:".($database_port ?? '');
     // We end right here and dont collect any more errors
     set_error($sMsg, "", true);
 }


### PR DESCRIPTION
If the db-settings do not fitt (e.g. wrong password for the db) the installation breaks  
with a warning:
>> Warning: Undefined variable $database_port in /~/wbce168/wbce/install/save.php on line 281
and 
>> Warning: Cannot modify header information - headers already sent by (output started at /xxx/cms-scriptorium/....