### PR TITLE
Funktion "make_thumb" wirft Deprecated-Message unter PHP 8.4

### DIFF
--- a/wbce/framework/functions.php
+++ b/wbce/framework/functions.php
@@ -1036,10 +1036,10 @@ if (!function_exists('mime_content_type')) {
  *
  * @param string $source
  * @param string $destination
- * @param int $size
+ * @param int    $size
  * @return  bool
  */
-function make_thumb($source, $destination, $size)
+function make_thumb(string $source, string $destination, int $size): bool
 {
     // Check if GD is installed
     if (extension_loaded('gd') && function_exists('imageCreateFromJpeg')) {
@@ -1047,10 +1047,10 @@ function make_thumb($source, $destination, $size)
         list($original_x, $original_y) = getimagesize($source);
         if ($original_x > $original_y) {
             $thumb_w = $size;
-            $thumb_h = abs($original_y * ($size / $original_x));
+            $thumb_h = intval($original_y * ($size / $original_x));
         }
         if ($original_x < $original_y) {
-            $thumb_w = abs($original_x * ($size / $original_y));
+            $thumb_w = intval($original_x * ($size / $original_y));
             $thumb_h = $size;
         }
         if ($original_x == $original_y) {
@@ -1060,7 +1060,7 @@ function make_thumb($source, $destination, $size)
         // Now make the thumbnail
         $source = imageCreateFromJpeg($source);
         $dst_img = ImageCreateTrueColor(abs($thumb_w), abs($thumb_h));
-        imagecopyresampled($dst_img, $source, 0, 0, 0, 0, abs($thumb_w), abs($thumb_h), abs($original_x), abs($original_y));
+        imagecopyresampled($dst_img, $source, 0, 0, 0, 0, $thumb_w, $thumb_h, $original_x, $original_y);
         imagejpeg($dst_img, $destination);
         
         // Return true


### PR DESCRIPTION
#### poc:
- Bakery 2.0.26 unter WBCE 1.6.8 mit PHP 8.4
- Neues Produkt - Produktimage und "Resize" auf 400x300px
Wirft im Error-log die _Warning_ raus:
```
2026-07-27 - 00:59:43 +02:00 [Visitor Request] ~/wbce_168/wbce/modules/bakery/save_item.php
2026-07-27 - 00:59:43 +02:00 [Deprecated] ~/wbce_168/wbce/framework/functions.php:[1062]
from /bakery/save_item.php:[389] make_thumb "Implicit conversion from float 56.25 to int loses precision"
```

#### Problem:
file: ~/wbce_168/wbce/framework/functions.php:
line: ~1042 ff.

Die Function "make_thumb" benutzt "abs" (Absolutwert) um die "Bruchberechnungen"  
für die neue Bildgröße / die neuen Bildmaße - da bleibt aber ein "float" ein "float"  
und wird unter 8.4 nicht zu einem "int[-teger]" ...
(Siehe https://www.php.net/manual/de/function.abs.php)

#### Abhilfe  
- Anstatt "abs" halt das (klassische) "intval" zu benutzen.

Ähnliches auch in der Bakery in "pngthumb.php", Zeile 21 ff.  
Da wird offensichtlich _gar nichts_ gerundet ...
[commit at bss2][1]

----
Kind regards

[1]: https://github.com/CMS-Scriptorium/BSS2/commit/7bf3fcc517c86de44fdf85ed7cfc54a0fc0dd8ee
