### PR TITLE
Fix for miniform - reparsing droplets.

### DIFF
--- a/wbce/modules/miniform/view.php
+++ b/wbce/modules/miniform/view.php
@@ -320,6 +320,10 @@ $template = preg_replace('#\{(?=\S)(.*?)\}#s', '', $template);
 unset($var);
 unset($value);
 
+if (!function_exists('evalDroplets')) {
+    require_once WB_PATH."/modules/droplets/droplets.php";
+}
+evalDroplets($template);
 
 $spinner = '';
 if(!defined("spinnerloaded")) {


### PR DESCRIPTION
Using droplets in miniform-templates works as expected, but
after an error (e.g. missmatched CAPTCHA) and //relload// the form the droplets are not parsed!
